### PR TITLE
Partner preview block

### DIFF
--- a/sanity/desk-structure/configuration.js
+++ b/sanity/desk-structure/configuration.js
@@ -5,7 +5,8 @@ import {
 	MdPublic,
 	MdPlace,
 	MdPinDrop,
-	MdPhoneIphone
+	MdPhoneIphone,
+	MdBusinessCenter
 } from "react-icons/md";
 
 import JSONpreview from "./previews/json-preview";
@@ -54,6 +55,11 @@ export default S.listItem()
 					.title("Venues")
 					.icon(MdPinDrop)
 					.schemaType("venue")
-					.child(S.documentTypeList("venue").title("Venues"))
+					.child(S.documentTypeList("venue").title("Venues")),
+				S.listItem()
+					.title("Partner types")
+					.icon(MdBusinessCenter)
+					.schemaType("partnerType")
+					.child(S.documentTypeList("partnerType").title("Partner types"))
 			])
 	);

--- a/sanity/desk-structure/index.js
+++ b/sanity/desk-structure/index.js
@@ -21,7 +21,8 @@ const hiddenDocTypes = listItem =>
 		"appConfiguration",
 		"event",
 		"venue",
-		"arena"
+		"arena",
+		"partnerType"
 	].includes(listItem.getId());
 
 export default () =>

--- a/sanity/schemas/blocks/index.js
+++ b/sanity/schemas/blocks/index.js
@@ -1,7 +1,8 @@
 import advertisement from "./advertisement";
 import announcement from "./announcement";
-import textArea from "./text-area";
 import collapsible from "./collapsible";
+import textArea from "./text-area";
+import partnerPreview from "./partner-preview";
 
 export default {
 	title: "Blocks",
@@ -19,6 +20,9 @@ export default {
 		},
 		{
 			type: collapsible.name
+		},
+		{
+			type: partnerPreview.name
 		}
 	]
 };

--- a/sanity/schemas/blocks/partner-preview.js
+++ b/sanity/schemas/blocks/partner-preview.js
@@ -1,0 +1,24 @@
+export default {
+	title: "Partner Preview",
+	name: "partnerPreview",
+	type: "object",
+	fields: [
+		{
+			type: "array",
+			name: "partners",
+			of: [
+				{
+					type: "reference",
+					to: { type: "partner" }
+				}
+			]
+		}
+	],
+	preview: {
+		prepare() {
+			return {
+				title: "Partner preview"
+			};
+		}
+	}
+};

--- a/sanity/schemas/blocks/partner-preview.js
+++ b/sanity/schemas/blocks/partner-preview.js
@@ -4,6 +4,16 @@ export default {
 	type: "object",
 	fields: [
 		{
+			title: "Heading",
+			name: "heading",
+			type: "string"
+		},
+		{
+			title: "Subheading",
+			name: "subHeading",
+			type: "string"
+		},
+		{
 			type: "array",
 			name: "partners",
 			of: [

--- a/sanity/schemas/partner-type.js
+++ b/sanity/schemas/partner-type.js
@@ -1,0 +1,30 @@
+import { MdBusinessCenter } from "react-icons/md";
+import { localize, getDefaultLanguage } from "../utils/locale";
+import supportedLanguages from "../supported-languages";
+
+export default {
+	name: "partnerType",
+	type: "document",
+	icon: MdBusinessCenter,
+	fields: [
+		localize(
+			{
+				name: "name",
+				type: "string"
+			},
+			(lang, Rule) => (lang.isDefault ? Rule.required() : undefined)
+		)
+	],
+	preview: {
+		select: {
+			title: "name"
+		},
+		prepare: ({ title }) => ({
+			title: title[getDefaultLanguage().id],
+			subtitle: supportedLanguages
+				.filter(lang => !lang.isDefault)
+				.map(lang => `${lang.id.toUpperCase()}: ${title[lang.id]}`)
+				.join(", ")
+		})
+	}
+};

--- a/sanity/schemas/partner.js
+++ b/sanity/schemas/partner.js
@@ -15,6 +15,21 @@ export default {
 			validation: Rule => Rule.required()
 		},
 		{
+			name: "type",
+			title: "Type",
+			type: "string",
+			validation: Rule => Rule.required(),
+			options: {
+				list: [
+					{ title: "Eier og arrangør", value: "owner" },
+					{ title: "Hovedpartner", value: "main-partner" },
+					{ title: "Partner", value: "partner" },
+					{ title: "Støttepartner", value: "support-partner" }
+				],
+				layout: "radio"
+			}
+		},
+		{
 			name: "description",
 			title: "Description",
 			type: "array",

--- a/sanity/schemas/partner.js
+++ b/sanity/schemas/partner.js
@@ -1,5 +1,3 @@
-import supportedLanguages from "../supported-languages";
-import { getDefaultLanguage } from "../utils/locale";
 import { MdBusinessCenter } from "react-icons/md";
 
 export default {
@@ -16,13 +14,9 @@ export default {
 		},
 		{
 			name: "type",
-			title: "Type",
-			type: "string",
-			validation: Rule => Rule.required(),
-			options: {
-				list: ["Eier og arrangør", "Hovedpartner", "Partner", "Støttepartner"],
-				layout: "radio"
-			}
+			title: "Partner type",
+			type: "reference",
+			to: { type: "partnerType" }
 		},
 		{
 			name: "description",
@@ -50,13 +44,6 @@ export default {
 	preview: {
 		select: {
 			title: "name"
-		},
-		prepare: ({ title }) => ({
-			title: title[getDefaultLanguage().id],
-			subtitle: supportedLanguages
-				.filter(lang => !lang.isDefault)
-				.map(lang => `${lang.id.toUpperCase()}: ${title[lang.id]}`)
-				.join(", ")
-		})
+		}
 	}
 };

--- a/sanity/schemas/partner.js
+++ b/sanity/schemas/partner.js
@@ -20,12 +20,7 @@ export default {
 			type: "string",
 			validation: Rule => Rule.required(),
 			options: {
-				list: [
-					{ title: "Eier og arrangør", value: "owner" },
-					{ title: "Hovedpartner", value: "main-partner" },
-					{ title: "Partner", value: "partner" },
-					{ title: "Støttepartner", value: "support-partner" }
-				],
+				list: ["Eier og arrangør", "Hovedpartner", "Partner", "Støttepartner"],
 				layout: "radio"
 			}
 		},

--- a/sanity/schemas/schema.js
+++ b/sanity/schemas/schema.js
@@ -14,6 +14,7 @@ import partner from "./partner";
 import event from "./event";
 import arena from "./arena";
 import venue from "./venue";
+import partnerType from "./partner-type";
 
 // Blocks
 import blocks from "./blocks";
@@ -43,6 +44,7 @@ export default createSchema({
 		event,
 		arena,
 		venue,
+		partnerType,
 
 		blocks,
 		textArea,

--- a/sanity/schemas/schema.js
+++ b/sanity/schemas/schema.js
@@ -21,6 +21,7 @@ import textArea from "./blocks/text-area";
 import announcement from "./blocks/announcement";
 import advertisement from "./blocks/advertisement";
 import collapsible from "./blocks/collapsible";
+import partnerPreview from "./blocks/partner-preview";
 
 // Types
 import externalLink from "./types/external-link";
@@ -48,6 +49,7 @@ export default createSchema({
 		announcement,
 		advertisement,
 		collapsible,
+		partnerPreview,
 
 		internalLink,
 		externalLink

--- a/web/src/blocks/index.tsx
+++ b/web/src/blocks/index.tsx
@@ -3,6 +3,7 @@ import { SanityBlock, SanityUnknown } from "../sanity/models";
 import Announcement from "./announcement";
 import Advertisement from "./advertisement";
 import CollapsibleList from "./collapsible";
+import PartnerPreview from "./partner-preview";
 import TextArea from "./text-area";
 
 type Props = {
@@ -17,6 +18,8 @@ const Block: React.FC<Props> = props => {
 			return <Advertisement content={props.block} />;
 		case "collapsibleList":
 			return <CollapsibleList content={props.block} />;
+		case "partnerPreview":
+			return <PartnerPreview content={props.block} />;
 		case "textArea":
 			return <TextArea content={props.block} />;
 		default:

--- a/web/src/blocks/partner-preview.tsx
+++ b/web/src/blocks/partner-preview.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from "react";
 import { css } from "@emotion/core";
 import useSWR from "swr";
 
-import sanity, { urlFor } from "../sanity";
+import { urlFor } from "../sanity";
 import { SanityPartnerPreview, SanityPartner } from "../sanity/models";
 import SubHeading from "../components/sub-heading";
 
@@ -50,9 +50,8 @@ const PartnerPreview: React.FC<Props> = ({
 	content: { partners, heading, subHeading }
 }) => {
 	const refList = partners.map(ref => ref._ref);
-	const { data, error } = useSWR<SanityPartner[]>(
-		`*[_id in ${JSON.stringify(refList)}]`,
-		query => sanity.fetch(query)
+	const { data } = useSWR<SanityPartner[]>(
+		`*[_id in ${JSON.stringify(refList)}]`
 	);
 
 	// sanity query does not return documents in same order as reference array

--- a/web/src/blocks/partner-preview.tsx
+++ b/web/src/blocks/partner-preview.tsx
@@ -53,9 +53,7 @@ const PartnerPreview: React.FC<Props> = ({
 }) => {
 	const refList = partners.map(ref => ref._ref);
 	const { data } = useSWR<DereferencedSanityPartner[]>(
-		`*[_id in ${JSON.stringify(
-			refList
-		)}]{..., "type": type->name}`
+		`*[_id in ${JSON.stringify(refList)}]{..., "type": type->name}`
 	);
 
 	// sanity query does not return documents in same order as reference array

--- a/web/src/blocks/partner-preview.tsx
+++ b/web/src/blocks/partner-preview.tsx
@@ -1,32 +1,95 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { css } from "@emotion/core";
 import useSWR from "swr";
 
-import sanity from "../sanity";
+import sanity, { urlFor } from "../sanity";
 import { SanityPartnerPreview, SanityPartner } from "../sanity/models";
-import theme from "../utils/theme";
+import SubHeading from "../components/sub-heading";
+
+const container = css`
+	padding: 0;
+	display: flex;
+	flex-wrap: wrap;
+	@media (max-width: 600px) {
+		justify-content: space-between;
+	}
+`;
+
+const logo = css`
+	margin-bottom: 1.3em;
+	max-height: 150px;
+	max-width: 300px;
+	@media (min-width: 600px) {
+		max-height: 125px;
+		max-width: 250px;
+	}
+`;
+
+const partnerItem = css`
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+	margin: 1em;
+	@media (min-width: 600px) {
+		margin: 2em;
+	}
+`;
+
+const partnerType = css`
+	font-size: 0.9rem;
+	text-transform: uppercase;
+	text-align: center;
+	font-weight: 400;
+`;
 
 type Props = {
 	content: SanityPartnerPreview;
 };
 
-const PartnerPreview: React.FC<Props> = ({ content: { partners } }) => {
+const PartnerPreview: React.FC<Props> = ({
+	content: { partners, heading, subHeading }
+}) => {
 	const refList = partners.map(ref => ref._ref);
 	const { data, error } = useSWR<SanityPartner[]>(
 		`*[_id in ${JSON.stringify(refList)}]`,
 		query => sanity.fetch(query)
 	);
-	console.log(data);
+
+	// sanity query does not return documents in same order as reference array
+	const orderedPartners = useMemo(() => {
+		return data ? refList.map(ref => data.find(doc => doc._id === ref)) : [];
+	}, [data]);
 
 	return (
-		<div
-			css={css`
-				padding: 15px;
-			`}
-		>
-			<h2>2</h2>
-			<h2>1</h2>
-		</div>
+		<section>
+			<SubHeading>{heading}</SubHeading>
+			<h3>{subHeading}</h3>
+			<ul css={container}>
+				{orderedPartners.map(
+					partner =>
+						partner && (
+							<li key={partner.name} css={partnerItem}>
+								<a
+									href={partner.url}
+									css={css`
+										text-align: center;
+									`}
+								>
+									<img
+										css={logo}
+										src={
+											urlFor(partner.image)
+												.width(300)
+												.url() || undefined
+										}
+									/>
+								</a>
+								<span css={partnerType}>{partner.type}</span>
+							</li>
+						)
+				)}
+			</ul>
+		</section>
 	);
 };
 

--- a/web/src/blocks/partner-preview.tsx
+++ b/web/src/blocks/partner-preview.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import { css } from "@emotion/core";
+import useSWR from "swr";
+
+import sanity from "../sanity";
+import { SanityPartnerPreview, SanityPartner } from "../sanity/models";
+import theme from "../utils/theme";
+
+type Props = {
+	content: SanityPartnerPreview;
+};
+
+const PartnerPreview: React.FC<Props> = ({ content: { partners } }) => {
+	const refList = partners.map(ref => ref._ref);
+	const { data, error } = useSWR<SanityPartner[]>(
+		`*[_id in ${JSON.stringify(refList)}]`,
+		query => sanity.fetch(query)
+	);
+	console.log(data);
+
+	return (
+		<div
+			css={css`
+				padding: 15px;
+			`}
+		>
+			<h2>2</h2>
+			<h2>1</h2>
+		</div>
+	);
+};
+
+export default PartnerPreview;

--- a/web/src/blocks/partner-preview.tsx
+++ b/web/src/blocks/partner-preview.tsx
@@ -3,7 +3,7 @@ import { css } from "@emotion/core";
 import useSWR from "swr";
 
 import { urlFor } from "../sanity";
-import { SanityPartnerPreview, SanityPartner } from "../sanity/models";
+import { SanityPartnerPreview, SanityPartner, Locale } from "../sanity/models";
 import SubHeading from "../components/sub-heading";
 
 const container = css`
@@ -42,6 +42,8 @@ const partnerType = css`
 	font-weight: 400;
 `;
 
+type DereferencedSanityPartner = SanityPartner & { type: Locale<string> };
+
 type Props = {
 	content: SanityPartnerPreview;
 };
@@ -50,10 +52,12 @@ const PartnerPreview: React.FC<Props> = ({
 	content: { partners, heading, subHeading }
 }) => {
 	const refList = partners.map(ref => ref._ref);
-	const { data } = useSWR<SanityPartner[]>(
-		`*[_id in ${JSON.stringify(refList)}]`
+	const { data } = useSWR<DereferencedSanityPartner[]>(
+		`*[_id in ${JSON.stringify(
+			refList
+		)}]{_id, name, image, url, "type": type->name}`
 	);
-
+	console.log(data);
 	// sanity query does not return documents in same order as reference array
 	const orderedPartners = useMemo(() => {
 		return data ? refList.map(ref => data.find(doc => doc._id === ref)) : [];
@@ -83,7 +87,7 @@ const PartnerPreview: React.FC<Props> = ({
 										}
 									/>
 								</a>
-								<span css={partnerType}>{partner.type}</span>
+								<span css={partnerType}>{partner.type.no}</span>
 							</li>
 						)
 				)}

--- a/web/src/blocks/partner-preview.tsx
+++ b/web/src/blocks/partner-preview.tsx
@@ -55,9 +55,9 @@ const PartnerPreview: React.FC<Props> = ({
 	const { data } = useSWR<DereferencedSanityPartner[]>(
 		`*[_id in ${JSON.stringify(
 			refList
-		)}]{_id, name, image, url, "type": type->name}`
+		)}]{..., "type": type->name}`
 	);
-	console.log(data);
+
 	// sanity query does not return documents in same order as reference array
 	const orderedPartners = useMemo(() => {
 		return data ? refList.map(ref => data.find(doc => doc._id === ref)) : [];

--- a/web/src/components/sub-heading.tsx
+++ b/web/src/components/sub-heading.tsx
@@ -1,0 +1,22 @@
+import styled from "@emotion/styled";
+
+import theme from "../utils/theme";
+
+const SubHeading = styled.span`
+	display: inline-flex;
+	text-transform: uppercase;
+	font-size: 0.85rem;
+	letter-spacing: 2px;
+	font-weight: 600;
+
+	::before {
+		content: "";
+		width: 3em;
+		height: 2px;
+		background-color: ${theme.color.main.pink};
+		place-self: center;
+		margin-right: 1em;
+	}
+`;
+
+export default SubHeading;

--- a/web/src/pages/front-page.tsx
+++ b/web/src/pages/front-page.tsx
@@ -5,6 +5,7 @@ import { urlFor } from "../sanity";
 import { SanityFrontPage } from "../sanity/models";
 import Block from "../blocks";
 import Hero from "../components/hero";
+import SubHeading from "../components/sub-heading";
 import { LinkButton } from "../components/link";
 import { css } from "@emotion/core";
 import useWindowSize from "../utils/use-window-size";
@@ -20,23 +21,6 @@ const date = css`
 
 const hero = css`
 	color: #ffffff;
-
-	span {
-		display: inline-flex;
-		text-transform: uppercase;
-		font-size: 0.85rem;
-		letter-spacing: 2px;
-		font-weight: 600;
-
-		::before {
-			content: "";
-			width: 3em;
-			height: 2px;
-			background-color: #e350a0;
-			place-self: center;
-			margin-right: 1em;
-		}
-	}
 
 	h2 {
 		font-size: calc(2rem + 1.7vw);
@@ -98,7 +82,7 @@ const FrontPage: React.FC<Props> = () => {
 				css={hero}
 			>
 				{width > 700 ? (
-					<span>Oslo Pride</span>
+					<SubHeading>Oslo Pride</SubHeading>
 				) : (
 					<h1 css={date}>{config?.date}</h1>
 				)}

--- a/web/src/sanity/models.ts
+++ b/web/src/sanity/models.ts
@@ -117,11 +117,19 @@ export type SanityCollapsibleList = SanityObject<
 	}
 >;
 
+export type SanityPartnerPreview = SanityObject<
+	"partnerPreview",
+	{
+		partners: SanityObjectArray<SanityReference>;
+	}
+>;
+
 export type SanityBlock =
 	| SanityAnnouncement
 	| SanityAdvertisement
 	| SanityTextArea
-	| SanityCollapsibleList;
+	| SanityCollapsibleList
+	| SanityPartnerPreview;
 
 /**
  *
@@ -149,6 +157,17 @@ export type SanityPage = SanityDocument<
 			"localeBlocks",
 			Locale<SanityObjectArray<SanityBlock>>
 		>;
+	}
+>;
+
+export type SanityPartner = SanityDocument<
+	"partner",
+	{
+		name: string;
+		type: string;
+		description: SanityBlockContent;
+		url: string;
+		image: SanityImage;
 	}
 >;
 

--- a/web/src/sanity/models.ts
+++ b/web/src/sanity/models.ts
@@ -166,7 +166,7 @@ export type SanityPartner = SanityDocument<
 	"partner",
 	{
 		name: string;
-		type: string;
+		type: SanityReference;
 		description: SanityBlockContent;
 		url: string;
 		image: SanityImage;

--- a/web/src/sanity/models.ts
+++ b/web/src/sanity/models.ts
@@ -120,6 +120,8 @@ export type SanityCollapsibleList = SanityObject<
 export type SanityPartnerPreview = SanityObject<
 	"partnerPreview",
 	{
+		heading: string;
+		subHeading: string;
 		partners: SanityObjectArray<SanityReference>;
 	}
 >;


### PR DESCRIPTION
Adds a partner preview block (front page partner list with images + partner "level").

I added a `Partner type` to the configuration where you can select what partner types are available, along with referencing this for each `Partner`.

I also added a Typescript model for the `Partner` document since it was missing.

Should probably be its own PR but whatever: also moved out the "sub-heading" into its own component (the heading with a pink line next to it), since I had to re-use it.

The styling is very much less than optimal and more of a quick draft right now. I'm not sure it makes much sense to spend hours on making things pixel perfect until more of the web site is fleshed out and it can be seen in a proper context.

Closes #30 