### PR TITLE
Quote block

### DIFF
--- a/sanity/schemas/blocks/index.js
+++ b/sanity/schemas/blocks/index.js
@@ -4,6 +4,7 @@ import textArea from "./text-area";
 import partnerList from "./partner-list";
 import collapsible from "./collapsible";
 import partnerPreview from "./partner-preview";
+import quote from "./quote";
 
 export default {
 	title: "Blocks",
@@ -27,6 +28,9 @@ export default {
 		},
 		{
 			type: partnerPreview.name
+		},
+		{
+			type: quote.name
 		}
 	]
 };

--- a/sanity/schemas/blocks/quote.js
+++ b/sanity/schemas/blocks/quote.js
@@ -1,0 +1,35 @@
+import { localize, getDefaultLanguage } from "../../utils/locale";
+import supportedLanguages from "../../supported-languages";
+
+export default {
+	title: "Quote",
+	name: "quote",
+	type: "object",
+	fields: [
+		localize(
+			{
+				title: "Content",
+				name: "content",
+				type: "string"
+			},
+			(lang, Rule) => lang.isDefault && Rule.required()
+		),
+		{
+			title: "Citation source",
+			name: "citation",
+			type: "string"
+		}
+	],
+	preview: {
+		select: {
+			title: "content"
+		},
+		prepare: ({ title }) => ({
+			title: title[getDefaultLanguage().id],
+			subtitle: supportedLanguages
+				.filter(lang => !lang.isDefault)
+				.map(lang => `${lang.id.toUpperCase()}: ${title[lang.id]}`)
+				.join(", ")
+		})
+	}
+};

--- a/sanity/schemas/schema.js
+++ b/sanity/schemas/schema.js
@@ -24,6 +24,7 @@ import advertisement from "./blocks/advertisement";
 import partnerList from "./blocks/partner-list";
 import collapsible from "./blocks/collapsible";
 import partnerPreview from "./blocks/partner-preview";
+import quote from "./blocks/quote";
 
 // Types
 import externalLink from "./types/external-link";
@@ -54,6 +55,7 @@ export default createSchema({
 		partnerList,
 		collapsible,
 		partnerPreview,
+		quote,
 
 		internalLink,
 		externalLink

--- a/web/src/assets/triangles-1.svg
+++ b/web/src/assets/triangles-1.svg
@@ -1,0 +1,23 @@
+<svg version="1.1" 
+	xmlns="http://www.w3.org/2000/svg" 
+	xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 300 300">
+	<style type="text/css">
+	.st0{display:none;}
+	.st1{display:inline;fill:#E350A0;}
+	.st2{display:inline;fill:#AEC2E6;}
+	.st3{display:inline;fill:#FFC100;}
+	.st4{fill:#FFC100;}
+	.st5{fill:#E350A0;}
+	.st6{fill:#AEC2E6;}
+	</style>
+	<g id="Layer_1" class="st0">
+		<path id="Path_215" class="st1" d="M298.5,110.3L179.7,99l69.2-97.2L298.5,110.3z"/>
+		<path id="Path_216" class="st2" d="M58.9,60.7l15.9-42.6l28.9,35.1L58.9,60.7z"/>
+		<path id="Path_217" class="st3" d="M213.1,180.6l61.2,74l-94.7,15.9L213.1,180.6z"/>
+	</g>
+	<g id="Layer_2">
+		<path id="Path_220" class="st4" d="M49.7,61.5l45.8,55.4l-70.9,11.9L49.7,61.5z"/>
+		<path id="Path_218" class="st5" d="M237.7,21.8l-4.3,55.9L187.1,46L237.7,21.8z"/>
+		<path id="Path_219" class="st6" d="M82.7,186.8l43.8,15.5l-35.3,30.2L82.7,186.8z"/>
+	</g>
+</svg>

--- a/web/src/assets/triangles-2.svg
+++ b/web/src/assets/triangles-2.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg version="1.1" id="Layer_1" 
+	xmlns="http://www.w3.org/2000/svg" 
+	xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 300 300">
+	<style type="text/css">
+	.st0{fill:#E350A0;}
+	.st1{fill:#AEC2E6;}
+	.st2{fill:#FFC100;}
+	</style>
+	<path id="Path_215" class="st0" d="M298.5,110.3L179.7,99l69.2-97.2L298.5,110.3z"/>
+	<path id="Path_216" class="st1" d="M58.9,60.7l15.9-42.6l28.9,35.1L58.9,60.7z"/>
+	<path id="Path_217" class="st2" d="M213.1,180.6l61.2,74l-94.7,15.9L213.1,180.6z"/>
+</svg>

--- a/web/src/blocks/index.tsx
+++ b/web/src/blocks/index.tsx
@@ -6,6 +6,7 @@ import CollapsibleList from "./collapsible";
 import PartnerPreview from "./partner-preview";
 import TextArea from "./text-area";
 import PartnerList from "./partner-list";
+import Quote from "./quote";
 
 type Props = {
 	block: SanityBlock;
@@ -25,6 +26,8 @@ const Block: React.FC<Props> = props => {
 			return <TextArea content={props.block} />;
 		case "partnerList":
 			return <PartnerList content={props.block} />;
+		case "quote":
+			return <Quote content={props.block} />;
 		default:
 			console.warn(
 				`Unknown block type: ${(props.block as SanityUnknown)._type}`

--- a/web/src/blocks/quote.tsx
+++ b/web/src/blocks/quote.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { SanityQuote } from "../sanity/models";
+
+type Props = {
+	content: SanityQuote;
+};
+
+const Quote: React.FC<Props> = ({ content: { content, citation } }) => {
+	return (
+		<blockquote>
+			{content.no}
+			<cite>{citation}</cite>
+		</blockquote>
+	);
+};
+
+export default Quote;

--- a/web/src/blocks/quote.tsx
+++ b/web/src/blocks/quote.tsx
@@ -1,17 +1,70 @@
 import React from "react";
+import { css } from "@emotion/core";
+
 import { SanityQuote } from "../sanity/models";
+import { ReactComponent as Triangles1 } from "../assets/triangles-1.svg";
+import { ReactComponent as Triangles2 } from "../assets/triangles-2.svg";
+import theme from "../utils/theme";
+
+const wrapper = css`
+	display: flex;
+	justify-content: center;
+	align-items: flex-end;
+`;
+
+const quote = css`
+	font-size: 2.5rem;
+	font-size: min(max(24px, 4vw), 46px);
+	font-style: italic;
+	text-align: center;
+	margin: 0;
+	display: inline-block;
+
+	cite {
+		font-size: 0.7em;
+		display: block;
+		margin-top: 1.3em;
+		@media (min-width: 600px) {
+			display: none;
+		}
+	}
+
+	p {
+		margin: 0;
+	}
+
+	@media (max-width: 600px) {
+		&::before {
+			width: 100%;
+			color: ${theme.color.main.pink};
+			content: "“";
+			font-size: 20vw;
+		}
+	}
+`;
+
+const triangles = css`
+	flex-grow: 1;
+	min-width: 150px;
+	max-width: 350px;
+	@media (max-width: 600px) {
+		display: none;
+	}
+`;
 
 type Props = {
 	content: SanityQuote;
 };
 
-const Quote: React.FC<Props> = ({ content: { content, citation } }) => {
-	return (
-		<blockquote>
-			{content.no}
-			<cite>{citation}</cite>
+const Quote: React.FC<Props> = ({ content: { content, citation } }) => (
+	<div css={wrapper}>
+		<Triangles1 css={triangles} />
+		<blockquote css={quote}>
+			<p>{content.no}</p>
+			<cite>- {citation}</cite>
 		</blockquote>
-	);
-};
+		<Triangles2 css={triangles} />
+	</div>
+);
 
 export default Quote;

--- a/web/src/sanity/models.ts
+++ b/web/src/sanity/models.ts
@@ -134,13 +134,22 @@ export type SanityPartnerPreview = SanityObject<
 	}
 >;
 
+export type SanityQuote = SanityObject<
+	"quote",
+	{
+		content: Locale<string>;
+		citation: string;
+	}
+>;
+
 export type SanityBlock =
 	| SanityAnnouncement
 	| SanityAdvertisement
 	| SanityTextArea
 	| SanityPartnerList
 	| SanityCollapsibleList
-	| SanityPartnerPreview;
+	| SanityPartnerPreview
+	| SanityQuote;
 
 /**
  *


### PR DESCRIPTION
Currently in the design this block seems to be more specific to being used as a quote (by seeing the mobile version where the triangle graphics are replaced by a quotation mark at the top?), rather than as a banner.

I decided to start off with creating this as a quote block instead of a generic banner block because of this. We could make a more generic banner component with the triangles later, when it's actually used anywhere else in the design? What do you think about that approach?

Closes #29 