### PR TITLE
Split pane block

### DIFF
--- a/sanity/schemas/blocks/index.js
+++ b/sanity/schemas/blocks/index.js
@@ -3,6 +3,7 @@ import announcement from "./announcement";
 import textArea from "./text-area";
 import partnerList from "./partner-list";
 import collapsible from "./collapsible";
+import splitPane from "./split-pane";
 import quote from "./quote";
 
 export default {
@@ -24,6 +25,9 @@ export default {
 		},
 		{
 			type: collapsible.name
+		},
+		{
+			type: splitPane.name
 		},
 		{
 			type: quote.name

--- a/sanity/schemas/blocks/split-pane.js
+++ b/sanity/schemas/blocks/split-pane.js
@@ -1,0 +1,26 @@
+export default {
+	title: "Split Pane",
+	name: "splitPane",
+	type: "object",
+	fields: [
+		{
+			title: "Left",
+			name: "left",
+			type: "textArea",
+			validate: Rule => Rule.required()
+		},
+		{
+			title: "Right",
+			name: "right",
+			type: "textArea",
+			validate: Rule => Rule.required()
+		}
+	],
+	preview: {
+		prepare() {
+			return {
+				title: "Split Pane"
+			};
+		}
+	}
+};

--- a/sanity/schemas/schema.js
+++ b/sanity/schemas/schema.js
@@ -27,6 +27,7 @@ import announcement from "./blocks/announcement";
 import advertisement from "./blocks/advertisement";
 import partnerList from "./blocks/partner-list";
 import collapsible from "./blocks/collapsible";
+import splitPane from "./blocks/split-pane";
 import quote from "./blocks/quote";
 
 // Types
@@ -63,6 +64,7 @@ export default createSchema({
 		advertisement,
 		partnerList,
 		collapsible,
+		splitPane,
 		quote,
 
 		internalLink,

--- a/web/src/blocks/index.tsx
+++ b/web/src/blocks/index.tsx
@@ -4,6 +4,7 @@ import Announcement from "./announcement";
 import Advertisement from "./advertisement";
 import CollapsibleList from "./collapsible";
 import TextArea from "./text-area";
+import SplitPane from "./split-pane";
 import Quote from "./quote";
 
 type Props = {
@@ -20,6 +21,8 @@ const Block: React.FC<Props> = props => {
 			return <CollapsibleList content={props.block} />;
 		case "textArea":
 			return <TextArea content={props.block} />;
+		case "splitPane":
+			return <SplitPane content={props.block} />;
 		case "quote":
 			return <Quote content={props.block} />;
 		default:

--- a/web/src/blocks/split-pane.tsx
+++ b/web/src/blocks/split-pane.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import BlockContentToReact from "@sanity/block-content-to-react";
+import { css } from "@emotion/core";
+
+import { SanitySplitPane } from "../sanity/models";
+
+const wrapper = css`
+	display: flex;
+	flex-direction: row;
+	justify-content: center;
+	@media (max-width: 600px) {
+		flex-direction: column;
+	}
+`;
+
+type Props = {
+	content: SanitySplitPane;
+};
+
+const SplitPane: React.FC<Props> = ({ content: { left, right } }) => (
+	<div css={wrapper}>
+		<BlockContentToReact blocks={left.text} />
+		<BlockContentToReact blocks={right.text} />
+	</div>
+);
+
+export default SplitPane;

--- a/web/src/sanity/models.ts
+++ b/web/src/sanity/models.ts
@@ -128,6 +128,14 @@ export type SanityPartnerPreview = SanityObject<
 	}
 >;
 
+export type SanitySplitPane = SanityObject<
+	"splitPane",
+	{
+		left: SanityTextArea;
+		right: SanityTextArea;
+	}
+>;
+
 export type SanityQuote = SanityObject<
 	"quote",
 	{
@@ -142,6 +150,7 @@ export type SanityBlock =
 	| SanityTextArea
 	| SanityCollapsibleList
 	| SanityPartnerPreview
+	| SanitySplitPane
 	| SanityQuote;
 
 /**


### PR DESCRIPTION
I assumed it might make sense to simply limit it to two text area blocks (left and right field), since the main purpose would be to have text columns? Otherwise maybe it should be an array of any block -- but it's probably dumb to leave it so open-ended for the user?

I didn't do any particular styling for the block for now, besides a responsive flex direction change. I figured that maybe it's worth waiting until more of the site-wide styling is implemented, so that it can share some of the regular text area styling when that is added later.

Closes #25 