### PR TITLE
Design cleanup

### DIFF
--- a/sanity/schemas/article-archive.js
+++ b/sanity/schemas/article-archive.js
@@ -6,6 +6,14 @@ export default {
 	type: "document",
 	fieldsets: [{ name: "header", title: "Header" }],
 	fields: [
+		{
+			title: "URL",
+			name: "slug",
+			type: "slug",
+			options: {
+				source: "header.en.title.id"
+			}
+		},
 		localize(
 			{
 				title: "Title",
@@ -33,6 +41,6 @@ export default {
 		}
 	],
 	preview: {
-		prepare: () => ({ title: "Front Page" })
+		prepare: () => ({ title: "Article Archive" })
 	}
 };

--- a/sanity/schemas/types/internal-link.js
+++ b/sanity/schemas/types/internal-link.js
@@ -13,7 +13,7 @@ export default {
 			title: "URL",
 			name: "url",
 			type: "reference",
-			to: [{ type: "page" }, { type: "frontPage" }],
+			to: [{ type: "page" }, { type: "frontPage" }, { type: "articleArchive" }],
 			validate: Rule => Rule.required()
 		}
 	]

--- a/web/src/components/angled-image.tsx
+++ b/web/src/components/angled-image.tsx
@@ -5,8 +5,32 @@ export type angleDirection = "<" | ">";
 type Props = {
 	direction: angleDirection;
 	angleHeight: string;
-	overlayColor: string;
+	overlayColor: Array<string>;
 	imageUrl: string;
+};
+
+const getGradient = (colorList: Array<string>, direction: string) => {
+	if (colorList.length > 1) {
+		let output = "background-image: linear-gradient(";
+		if (direction === "<") {
+			output += "190deg, ";
+		} else {
+			output += "170deg, ";
+		}
+		colorList.forEach((color, index) => {
+			output += color;
+			if (index === 0) {
+				output += " 15%";
+			}
+			if (index < colorList.length - 1) {
+				output += ",";
+			}
+		});
+		output += ")";
+		return output;
+	} else {
+		return null;
+	}
 };
 
 const AngledImage = styled.figure<Props>`
@@ -27,8 +51,11 @@ const AngledImage = styled.figure<Props>`
 		left: 0;
 		right: 0;
 		bottom: 0;
-		background-color: ${props => props.overlayColor};
-		opacity: 0.75;
+		background-color: ${props => props.overlayColor[0]};
+		${props => getGradient(props.overlayColor, props.direction)};
+		background-size: 150% 150%;
+		background-position: top left;
+		opacity: 0.85;
 	}
 `;
 

--- a/web/src/components/footer/styles.ts
+++ b/web/src/components/footer/styles.ts
@@ -4,15 +4,22 @@ import styled from "@emotion/styled";
 export const StickyFooter = styled.footer`
 	background-color: ${theme.color.main.purple};
 	color: ${theme.color.text.white};
-	font-size: 16px;
+	font-size: 1rem;
 `;
 
 export const Footer = styled.div`
-	display: flex;
-	flex-flow: row wrap;
-	justify-content: space-around;
-	width: 70%;
-	margin: 50px auto;
+	width: 90vw;
+	max-width: 900px;
+	margin: 2.75rem auto;
+
+	display: -ms-grid;
+	-ms-grid-columns: 3fr 2fr 1fr;
+
+	display: grid;
+	grid-template-columns: 3fr 2fr 1fr;
+	column-gap: 1rem;
+
+	padding: 2.5rem 0;
 
 	a {
 		color: ${theme.color.background.pink};
@@ -20,47 +27,23 @@ export const Footer = styled.div`
 
 	a,
 	p {
-		margin: 5px 0;
-	}
-
-	> div {
-		flex: 1;
-		margin: 0 20px;
-
-		:nth-of-type(1) {
-			flex: 2;
-		}
-	}
-
-	@media (max-width: 767px) {
-		text-align: center;
-
-		> div {
-			flex: 1 0 100%;
-			padding: 20px;
-		}
-
-		ul,
-		h3 {
-			margin-left: 0;
-		}
+		margin: 0.25rem 0;
 	}
 `;
 
 export const Image = styled.div`
 	img {
-		width: 180px;
+		width: 10rem;
 		fill: ${theme.color.text.white};
+		margin-left: -1rem;
 	}
 	h3 {
 		text-transform: uppercase;
-		margin-left: 20px;
 		margin-top: 8px;
 		font-weight: 500;
 	}
 
 	ul {
-		margin-left: 20px;
 		list-style: none;
 		padding: 0;
 	}
@@ -81,7 +64,7 @@ export const Shortcuts = styled.div`
 		padding: 0;
 
 		li {
-			margin: 5px 0;
+			margin: 0.25rem 0;
 		}
 	}
 `;

--- a/web/src/components/footer/styles.ts
+++ b/web/src/components/footer/styles.ts
@@ -29,6 +29,12 @@ export const Footer = styled.div`
 	p {
 		margin: 0.25rem 0;
 	}
+
+	@media screen and (max-width: 720px) {
+		-ms-grid-columns: 1fr;
+		grid-template-columns: 1fr;
+		text-align: center;
+	}
 `;
 
 export const Image = styled.div`

--- a/web/src/components/header.tsx
+++ b/web/src/components/header.tsx
@@ -41,7 +41,7 @@ const headerStyle = (fixedHeader: boolean) => css`
 		}
 
 		@media screen and (max-width: 850px) {
-			left: 2vw;
+			left: 1vw;
 		}
 	}
 
@@ -153,6 +153,10 @@ const buttonStyle = css`
 
 	background-repeat: no-repeat;
 	background-size: auto 30px;
+
+	@media screen and (max-width: 850px) {
+		right: calc(1vw + 1rem);
+	}
 `;
 
 const closeButton = (close: string) => css`
@@ -186,9 +190,9 @@ const Header: React.FC<Props> = () => {
 
 	React.useEffect(() => {
 		const scrollHandler = () => {
-			if (window.pageYOffset > 100) {
+			if (window.pageYOffset > 70) {
 				setFixedHeader(true);
-			} else if (window.pageYOffset <= 100) {
+			} else if (window.pageYOffset <= 70) {
 				setFixedHeader(false);
 			}
 		};

--- a/web/src/components/header.tsx
+++ b/web/src/components/header.tsx
@@ -7,7 +7,6 @@ import logoWhite from "../assets/logo-white.svg";
 import menu from "../assets/menu.svg";
 import menuWhite from "../assets/menu-white.svg";
 import close from "../assets/close.svg";
-
 import useConfig from "../utils/use-config";
 
 type Props = {};
@@ -35,8 +34,10 @@ const headerStyle = (fixedHeader: boolean) => css`
 		width: 160px;
 		height: 80px;
 
-		span {
-			visibility: hidden;
+		a {
+			display: block;
+			width: 100%;
+			height: 100%;
 		}
 
 		@media screen and (max-width: 850px) {
@@ -65,6 +66,7 @@ const headerStyle = (fixedHeader: boolean) => css`
 `;
 
 const navigationStyle = css`
+	visibility: visible;
 	padding-top: 100px;
 	position: fixed;
 	top: 0;
@@ -131,8 +133,9 @@ const navigationStyle = css`
 `;
 
 const navigationStyleCollapsed = css`
+	visibility: hidden;
 	right: -100vw;
-	transition: right 1s;
+	transition: right 1s, visibility 2s, display 2s;
 `;
 
 const buttonStyle = css`
@@ -143,7 +146,6 @@ const buttonStyle = css`
 	height: 30px;
 	width: 35px;
 	border: none;
-	outline: none;
 	white-space: nowrap;
 	overflow: hidden;
 	cursor: pointer;
@@ -151,20 +153,36 @@ const buttonStyle = css`
 
 	background-repeat: no-repeat;
 	background-size: auto 30px;
-	text-indent: -9999px;
-	overflow: hidden;
 `;
 
 const closeButton = (close: string) => css`
 	background-image: url(${close});
 `;
 
+const hidden = css`
+	position: absolute !important;
+	height: 1px;
+	width: 1px;
+	overflow: hidden;
+	clip: rect(1px 1px 1px 1px); /* IE6, IE7 */
+	clip: rect(1px, 1px, 1px, 1px);
+	white-space: nowrap;
+`;
+
 const Header: React.FC<Props> = () => {
 	const { date, navigationBar } = useConfig();
 	const [navigationVisible, showNavigation] = React.useState(false);
-	const toggleNavigation = () => showNavigation(current => !current);
-
+	const [hasNavigated, setNavigation] = React.useState(false);
 	const [fixedHeader, setFixedHeader] = React.useState(false);
+	const openMenu = React.createRef<HTMLButtonElement>();
+	const closeMenu = React.createRef<HTMLButtonElement>();
+
+	const toggleNavigation = () => {
+		if (!hasNavigated) {
+			setNavigation(true);
+		}
+		showNavigation(current => !current);
+	};
 
 	React.useEffect(() => {
 		const scrollHandler = () => {
@@ -180,24 +198,49 @@ const Header: React.FC<Props> = () => {
 		return () => window.removeEventListener("scroll", scrollHandler);
 	}, []);
 
+	React.useEffect(() => {
+		if (navigationVisible && closeMenu.current) {
+			closeMenu.current.focus();
+		} else if (hasNavigated && openMenu.current) {
+			openMenu.current.focus();
+		}
+	}, [navigationVisible]);
+
 	return (
 		<>
 			<header css={headerStyle(fixedHeader)} id="pageHeader">
 				<h1>
-					<span>Oslo Pride</span>
+					<a href="/">
+						<span css={hidden}>Oslo Pride</span>
+					</a>
 				</h1>
 				<p>{date}</p>
-				<button css={buttonStyle} onClick={toggleNavigation}>
-					Menu
+				<button
+					css={buttonStyle}
+					onClick={toggleNavigation}
+					aria-haspopup="menu"
+					aria-controls="menu"
+					aria-expanded={navigationVisible}
+					ref={openMenu}
+				>
+					<span css={hidden}>Open Menu</span>
 				</button>
 			</header>
-			<nav
+			<div
+				id="menu"
 				css={
 					navigationVisible
 						? navigationStyle
 						: [navigationStyle, navigationStyleCollapsed]
 				}
 			>
+				<button
+					css={[buttonStyle, closeButton(close)]}
+					onClick={toggleNavigation}
+					ref={closeMenu}
+				>
+					<span css={hidden}>Close menu</span>
+				</button>
 				<ul>
 					{navigationBar?.map(item => (
 						<li key={item._key} onClick={toggleNavigation}>
@@ -205,13 +248,7 @@ const Header: React.FC<Props> = () => {
 						</li>
 					))}
 				</ul>
-				<button
-					css={[buttonStyle, closeButton(close)]}
-					onClick={toggleNavigation}
-				>
-					Close
-				</button>
-			</nav>
+			</div>
 		</>
 	);
 };

--- a/web/src/components/header.tsx
+++ b/web/src/components/header.tsx
@@ -96,12 +96,30 @@ const navigationStyle = css`
 			:before {
 				content: "";
 				display: block;
-				width: 50px;
+				width: 3rem;
 				height: 4px;
 				background-color: #e350a0;
 				position: absolute;
 				left: -0.5em;
 				top: 0.9em;
+			}
+		}
+	}
+
+	@media screen and (max-width: 930px) {
+		padding: 8rem 0rem;
+
+		li {
+			font-size: 2rem;
+
+			a {
+				padding-left: 2rem;
+
+				&:hover {
+					:before {
+						width: 1.5rem;
+					}
+				}
 			}
 		}
 	}

--- a/web/src/components/header.tsx
+++ b/web/src/components/header.tsx
@@ -82,6 +82,7 @@ const navigationStyle = css`
 	padding: 14rem 3rem;
 	z-index: 100;
 	transition: right 0.65s;
+	overflow-y: scroll;
 
 	li {
 		list-style: none;

--- a/web/src/components/header.tsx
+++ b/web/src/components/header.tsx
@@ -8,6 +8,7 @@ import menu from "../assets/menu.svg";
 import menuWhite from "../assets/menu-white.svg";
 import close from "../assets/close.svg";
 import useConfig from "../utils/use-config";
+import theme from "../utils/theme";
 
 type Props = {};
 
@@ -74,7 +75,7 @@ const navigationStyle = css`
 	width: 930px;
 	max-width: 100vw;
 	height: 100vh;
-	background: #352176;
+	background: ${theme.color.main.purple};
 	display: flex;
 	flex-direction: column;
 	align-items: left;

--- a/web/src/components/header.tsx
+++ b/web/src/components/header.tsx
@@ -16,6 +16,7 @@ const headerStyle = (fixedHeader: boolean) => css`
 	display: block;
 	height: 6rem;
 	width: 100%;
+	margin: 0 auto;
 	position: fixed;
 	top: 0;
 	left: 0;
@@ -36,6 +37,10 @@ const headerStyle = (fixedHeader: boolean) => css`
 
 		span {
 			visibility: hidden;
+		}
+
+		@media screen and (max-width: 850px) {
+			left: 2vw;
 		}
 	}
 

--- a/web/src/components/hero.tsx
+++ b/web/src/components/hero.tsx
@@ -31,6 +31,11 @@ const defaultContent = css`
 	@media screen and (max-width: 1200px) {
 		margin: auto;
 	}
+
+	@media screen and (min-width: 2000px) {
+		max-width: 1300px;
+		margin: auto;
+	}
 `;
 
 const centeredContent = css`

--- a/web/src/components/hero.tsx
+++ b/web/src/components/hero.tsx
@@ -6,7 +6,11 @@ import AngledImage, { angleDirection } from "./angled-image";
 const hero = (height: string) => css`
 	min-height: 400px;
 	height: ${height};
-	margin-bottom: -10rem;
+	padding-top: 13rem;
+
+	@media screen and (max-width: 800px) {
+		padding-top: 8rem;
+	}
 `;
 
 const image = (height: string) => css`
@@ -19,18 +23,18 @@ const image = (height: string) => css`
 	z-index: -1;
 `;
 
-const defaultContent = (marginBottom: string) => css`
-	margin: 10rem 0 ${marginBottom} 8rem;
+const defaultContent = css`
 	width: 90vw;
 	max-width: 900px;
+	margin-left: 8rem;
 
 	@media screen and (max-width: 1200px) {
-		margin: 10rem auto ${marginBottom} auto;
+		margin: auto;
 	}
 `;
 
-const centeredContent = (marginBottom: string) => css`
-	margin: 10rem auto ${marginBottom} auto;
+const centeredContent = css`
+	margin: auto;
 `;
 
 type Props = {
@@ -51,23 +55,11 @@ const Hero: React.FC<Props> = props => {
 		height,
 		imageUrl,
 		color,
-		overflow,
 		className,
 		children
 	} = props;
-	// Distance from the bottom of the content to the top of the page
-	const [contentBottomToPageTop, setContentBottomToPageTop] = React.useState<
-		number | undefined
-	>(undefined);
-	const contentRef = React.useRef<HTMLDivElement>(null);
 
-	React.useLayoutEffect(() => {
-		if (contentRef.current) {
-			setContentBottomToPageTop(
-				contentRef.current.offsetTop + contentRef.current.offsetHeight
-			);
-		}
-	}, []);
+	const contentRef = React.useRef<HTMLDivElement>(null);
 
 	const triangleHeight = rightAngledTriangleHeight(100, 6);
 
@@ -78,10 +70,10 @@ const Hero: React.FC<Props> = props => {
 			? `calc(${height} + ${triangleHeight}vw)`
 			: `calc(${height} + (${triangleHeight}vw / 2))`;
 
-	const childrenWrapper =
-		overflow || contentBottomToPageTop === undefined
-			? "0"
-			: `calc(${totalImageHeight} - ${contentBottomToPageTop}px - 0rem)`;
+	const contentClass =
+		props.textPosition === "center"
+			? [defaultContent, centeredContent]
+			: defaultContent;
 
 	return (
 		<div css={hero(totalImageHeight)}>
@@ -93,17 +85,7 @@ const Hero: React.FC<Props> = props => {
 				css={image(totalImageHeight)}
 			/>
 			<div className={className}>
-				<div
-					css={
-						props.textPosition === "center"
-							? [
-									defaultContent(childrenWrapper),
-									centeredContent(childrenWrapper)
-							  ]
-							: defaultContent(childrenWrapper)
-					}
-					ref={contentRef}
-				>
+				<div css={contentClass} ref={contentRef}>
 					{children}
 				</div>
 			</div>

--- a/web/src/components/hero.tsx
+++ b/web/src/components/hero.tsx
@@ -6,6 +6,7 @@ import AngledImage, { angleDirection } from "./angled-image";
 const hero = (height: string) => css`
 	min-height: 400px;
 	height: ${height};
+	margin-bottom: -10rem;
 `;
 
 const image = (height: string) => css`
@@ -18,8 +19,18 @@ const image = (height: string) => css`
 	z-index: -1;
 `;
 
-const content = (marginBottom: string) => css`
-	padding: calc(7rem + 7vw) 7vw ${marginBottom};
+const defaultContent = (marginBottom: string) => css`
+	margin: 10rem 0 ${marginBottom} 8rem;
+	width: 90vw;
+	max-width: 900px;
+
+	@media screen and (max-width: 1200px) {
+		margin: 10rem auto ${marginBottom} auto;
+	}
+`;
+
+const centeredContent = (marginBottom: string) => css`
+	margin: 10rem auto ${marginBottom} auto;
 `;
 
 type Props = {
@@ -27,9 +38,10 @@ type Props = {
 	angleDirection: angleDirection;
 	height: string;
 	imageUrl: string;
-	color: string;
+	color: Array<string>;
 	overflow?: boolean;
 	className?: string;
+	textPosition?: "center" | "left";
 };
 
 const Hero: React.FC<Props> = props => {
@@ -69,7 +81,7 @@ const Hero: React.FC<Props> = props => {
 	const childrenWrapper =
 		overflow || contentBottomToPageTop === undefined
 			? "0"
-			: `calc(${totalImageHeight} - ${contentBottomToPageTop}px)`;
+			: `calc(${totalImageHeight} - ${contentBottomToPageTop}px - 0rem)`;
 
 	return (
 		<div css={hero(totalImageHeight)}>
@@ -81,7 +93,17 @@ const Hero: React.FC<Props> = props => {
 				css={image(totalImageHeight)}
 			/>
 			<div className={className}>
-				<div css={content(childrenWrapper)} ref={contentRef}>
+				<div
+					css={
+						props.textPosition === "center"
+							? [
+									defaultContent(childrenWrapper),
+									centeredContent(childrenWrapper)
+							  ]
+							: defaultContent(childrenWrapper)
+					}
+					ref={contentRef}
+				>
 					{children}
 				</div>
 			</div>

--- a/web/src/components/hero.tsx
+++ b/web/src/components/hero.tsx
@@ -3,12 +3,18 @@ import { css } from "@emotion/core";
 import { rightAngledTriangleHeight } from "../utils";
 import AngledImage, { angleDirection } from "./angled-image";
 
+const hero = (height: string) => css`
+	min-height: 400px;
+	height: ${height};
+`;
+
 const image = (height: string) => css`
 	position: absolute;
 	top: 0;
 	left: 0;
 	width: 100%;
 	height: ${height};
+	min-height: 350px;
 	z-index: -1;
 `;
 
@@ -66,7 +72,7 @@ const Hero: React.FC<Props> = props => {
 			: `calc(${totalImageHeight} - ${contentBottomToPageTop}px)`;
 
 	return (
-		<>
+		<div css={hero(totalImageHeight)}>
 			<AngledImage
 				direction={angleDirection}
 				angleHeight={`${triangleHeight}vw`}
@@ -79,7 +85,7 @@ const Hero: React.FC<Props> = props => {
 					{children}
 				</div>
 			</div>
-		</>
+		</div>
 	);
 };
 

--- a/web/src/components/link.tsx
+++ b/web/src/components/link.tsx
@@ -63,13 +63,15 @@ export const LinkButton = styled(Link)<LinkButtonProps>`
 	background-color: ${props =>
 		props.color === "pink" ? theme.color.main.pink : theme.color.main.blue};
 	text-transform: uppercase;
-	letter-spacing: 2px;
-	padding: 1em 1.7em;
+	letter-spacing: 1px;
+	padding: 1rem 1.75rem;
 	text-decoration: none;
 	cursor: pointer;
 	border-radius: 4px;
 	color: ${props => (props.color === "pink" ? "#371755" : "#ffffff")};
 	font-weight: bold;
+	font-size: 1rem;
+	transition: color 0.3s, background 0.3s;
 
 	:hover {
 		color: #ffffff;

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -26,6 +26,7 @@ const globalStyles = css`
 	#app {
 		height: 100%;
 		font-size: 18px;
+		color: #252525;
 	}
 
 	body {
@@ -40,6 +41,10 @@ const globalStyles = css`
 	main {
 		flex: 1 0 auto;
 		margin-bottom: 32px;
+
+		p {
+			font-size: 1.1rem;
+		}
 	}
 
 	footer {

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -7,6 +7,7 @@ import { hot } from "react-hot-loader/root";
 import { SWRConfig } from "swr";
 import sanity, { previewMode } from "./sanity";
 import App from "./app";
+import theme from "./utils/theme";
 
 WebFont.load({
 	typekit: {
@@ -27,6 +28,15 @@ const globalStyles = css`
 		height: 100%;
 		font-size: 18px;
 		color: #252525;
+	}
+
+	::selection {
+		background-color: ${theme.color.background.pink};
+		color: ${theme.color.main.purple};
+	}
+
+	*:focus {
+		outline: 3px dotted ${theme.color.main.pink};
 	}
 
 	body {

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -36,7 +36,7 @@ const globalStyles = css`
 	}
 
 	*:focus {
-		outline: 3px dotted ${theme.color.main.pink};
+		outline: 2px dotted ${theme.color.main.pink};
 	}
 
 	body {

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -35,8 +35,8 @@ const globalStyles = css`
 		color: ${theme.color.main.purple};
 	}
 
-	*:focus {
-		outline: 2px dotted ${theme.color.main.pink};
+	button:focus {
+		outline: 1px dotted ${theme.color.background.pink};
 	}
 
 	body {

--- a/web/src/pages/article-overview.tsx
+++ b/web/src/pages/article-overview.tsx
@@ -6,7 +6,6 @@ import { css } from "@emotion/core";
 import { urlFor } from "../sanity";
 import useSWR from "swr";
 import { SanityArchive, SanityArticleList } from "../sanity/models";
-import Block from "../blocks";
 import BlockContentToReact from "@sanity/block-content-to-react";
 
 type Props = { slug?: string } & RouteComponentProps;
@@ -28,9 +27,10 @@ const hero = css`
 
 const body = css`
 	display: block;
-	margin: -250px auto 0 auto;
+	margin: auto;
+	margin-top: calc(0vh - calc(5vh + 10.510423526567646vw));
 	width: 90vw;
-	max-width: 885px;
+	max-width: 720px;
 
 	p {
 		margin-bottom: 0;
@@ -54,9 +54,18 @@ const article = css`
 	min-height: 330px;
 	grid-template-columns: 1fr 1fr;
 	margin-bottom: 2rem;
+
+	div {
+		min-width: 50%;
+	}
+
+	@media screen and (max-width: 700px) {
+		grid-template-columns: 1fr;
+	}
 `;
 
 const image = (image: string) => css`
+	min-height: 330px;
 	height: 100%;
 	background-image: url(${image});
 	background-size: cover;

--- a/web/src/pages/article-overview.tsx
+++ b/web/src/pages/article-overview.tsx
@@ -28,7 +28,7 @@ const hero = css`
 const body = css`
 	display: block;
 	margin: auto;
-	margin-top: calc(calc(0vh - calc(5vh + 10.510423526567646vw)) - 10rem);
+	margin-top: calc(0vh - calc(5vh + 10.510423526567646vw));
 	width: 90vw;
 	max-width: 900px;
 
@@ -43,7 +43,7 @@ const body = css`
 
 	h3 {
 		margin: 0;
-		font-size: 2rem;
+		font-size: 1.75rem;
 	}
 `;
 
@@ -54,6 +54,11 @@ const article = css`
 	min-height: 330px;
 	grid-template-columns: 1fr 1fr;
 	margin-bottom: 2rem;
+
+	p {
+		font-size: 1.1rem;
+		line-height: 1.75rem;
+	}
 
 	div {
 		min-width: 50%;
@@ -79,6 +84,7 @@ const preview = css`
 const date = css`
 	text-transform: uppercase;
 	letter-spacing: 1px;
+	font-size: 0.75rem !important;
 	margin-bottom: 0.5rem !important;
 	font-weight: 600;
 `;

--- a/web/src/pages/article-overview.tsx
+++ b/web/src/pages/article-overview.tsx
@@ -20,7 +20,7 @@ const hero = css`
 	}
 
 	p {
-		font-size: 1rem;
+		font-size: 1.1rem;
 		margin: 0;
 	}
 `;
@@ -28,9 +28,9 @@ const hero = css`
 const body = css`
 	display: block;
 	margin: auto;
-	margin-top: calc(0vh - calc(5vh + 10.510423526567646vw));
+	margin-top: calc(calc(0vh - calc(5vh + 10.510423526567646vw)) - 10rem);
 	width: 90vw;
-	max-width: 720px;
+	max-width: 900px;
 
 	p {
 		margin-bottom: 0;
@@ -101,14 +101,15 @@ const ArticleOverview: React.FC<Props> = () => {
 			<Hero
 				angleDirection="<"
 				anglePosition="after"
-				height="50vh"
-				color={theme.color.main.purple}
+				height="500px"
+				color={[theme.color.main.purple]}
 				imageUrl={
 					urlFor(archive.image)
 						.width(window.innerWidth)
 						.url() || ""
 				}
 				css={hero}
+				textPosition="center"
 			>
 				<h2>{archive.title.no}</h2>
 				<p>{archive.subtitle.no}</p>

--- a/web/src/pages/article.tsx
+++ b/web/src/pages/article.tsx
@@ -53,6 +53,11 @@ const date = css`
 	font-weight: 600;
 `;
 
+const credits = css`
+	font-size: 1.1rem;
+	line-height: 1.75rem;
+`;
+
 const Page: React.FC<Props> = props => {
 	const { slug } = props;
 
@@ -69,7 +74,7 @@ const Page: React.FC<Props> = props => {
 			<Hero
 				angleDirection="<"
 				anglePosition="after"
-				height="50vh"
+				height="500px"
 				color={[theme.color.main.purple]}
 				imageUrl={
 					urlFor(page.image)
@@ -80,7 +85,7 @@ const Page: React.FC<Props> = props => {
 			>
 				<p css={date}>{page._createdAt.split("T")[0]}</p>
 				<h2>{page.title.no}</h2>
-				<BlockContentToReact blocks={page.credits?.no} />
+				<BlockContentToReact blocks={page.credits?.no} css={credits} />
 			</Hero>
 			<div css={[body, intro]}>
 				<BlockContentToReact blocks={page.intro?.no} />

--- a/web/src/pages/article.tsx
+++ b/web/src/pages/article.tsx
@@ -29,7 +29,8 @@ const hero = css`
 
 const body = css`
 	display: block;
-	width: 720px;
+	width: 90vw;
+	max-width: 720px;
 	margin-left: auto;
 	margin-right: auto;
 `;

--- a/web/src/pages/article.tsx
+++ b/web/src/pages/article.tsx
@@ -30,16 +30,19 @@ const hero = css`
 const body = css`
 	display: block;
 	width: 90vw;
-	max-width: 720px;
+	max-width: 900px;
 	margin-left: auto;
 	margin-right: auto;
+	p,
+	blockquote,
+	ul {
+		font-size: 1.1rem;
+		line-height: 1.75rem;
+		margin-bottom: 2rem;
+	}
 `;
 
 const intro = css`
-	display: block;
-	width: 720px;
-	margin-left: auto;
-	margin-right: auto;
 	font-weight: 500;
 `;
 
@@ -67,7 +70,7 @@ const Page: React.FC<Props> = props => {
 				angleDirection="<"
 				anglePosition="after"
 				height="50vh"
-				color={theme.color.main.purple}
+				color={[theme.color.main.purple]}
 				imageUrl={
 					urlFor(page.image)
 						.width(window.innerWidth)
@@ -79,7 +82,7 @@ const Page: React.FC<Props> = props => {
 				<h2>{page.title.no}</h2>
 				<BlockContentToReact blocks={page.credits?.no} />
 			</Hero>
-			<div css={intro}>
+			<div css={[body, intro]}>
 				<BlockContentToReact blocks={page.intro?.no} />
 			</div>
 			<div css={body}>

--- a/web/src/pages/front-page.tsx
+++ b/web/src/pages/front-page.tsx
@@ -24,12 +24,14 @@ const hero = css`
 	color: #ffffff;
 
 	h2 {
-		font-size: 3.5rem;
+		font-size: 3rem;
+		line-height: 3.5rem;
 		margin: 2rem 0;
 	}
 
 	p {
 		font-size: 1.1rem;
+		line-height: 1.75rem;
 		margin: 0;
 	}
 
@@ -73,7 +75,7 @@ const FrontPage: React.FC<Props> = () => {
 			<Hero
 				angleDirection=">"
 				anglePosition="after"
-				height="760px"
+				height="720px"
 				color={[theme.color.main.purple, theme.color.main.pink]}
 				imageUrl={
 					urlFor(data.header.no.image)

--- a/web/src/pages/front-page.tsx
+++ b/web/src/pages/front-page.tsx
@@ -24,12 +24,12 @@ const hero = css`
 	color: #ffffff;
 
 	h2 {
-		font-size: calc(2rem + 1.7vw);
+		font-size: 3.5rem;
 		margin: 2rem 0;
 	}
 
 	p {
-		font-size: 1rem;
+		font-size: 1.1rem;
 		margin: 0;
 	}
 
@@ -73,8 +73,8 @@ const FrontPage: React.FC<Props> = () => {
 			<Hero
 				angleDirection=">"
 				anglePosition="after"
-				height="100vh"
-				color={theme.color.main.purple}
+				height="760px"
+				color={[theme.color.main.purple, theme.color.main.pink]}
 				imageUrl={
 					urlFor(data.header.no.image)
 						.width(window.innerWidth)

--- a/web/src/pages/front-page.tsx
+++ b/web/src/pages/front-page.tsx
@@ -116,8 +116,8 @@ const FrontPage: React.FC<Props> = () => {
 					))}
 				</ul>
 			</Hero>
+			{data.callToAction && <Advertisement content={data.callToAction.no} />}
 			<div css={body}>
-				{data.callToAction && <Advertisement content={data.callToAction.no} />}
 				{data.featuredArticles && (
 					<FeaturedArticles content={data.featuredArticles} />
 				)}

--- a/web/src/pages/front-page.tsx
+++ b/web/src/pages/front-page.tsx
@@ -57,6 +57,17 @@ const hero = css`
 	}
 `;
 
+const body = css`
+	margin: 5vh auto 3rem auto;
+	width: 90vw;
+	max-width: 900px;
+
+	p {
+		font-size: 1.1rem;
+		margin: 0;
+	}
+`;
+
 type Props = {} & RouteComponentProps;
 
 const FrontPage: React.FC<Props> = () => {
@@ -105,10 +116,12 @@ const FrontPage: React.FC<Props> = () => {
 					))}
 				</ul>
 			</Hero>
-			{data.callToAction && <Advertisement content={data.callToAction.no} />}
-			{data.featuredArticles && (
-				<FeaturedArticles content={data.featuredArticles} />
-			)}
+			<div css={body}>
+				{data.callToAction && <Advertisement content={data.callToAction.no} />}
+				{data.featuredArticles && (
+					<FeaturedArticles content={data.featuredArticles} />
+				)}
+			</div>
 		</>
 	);
 };

--- a/web/src/pages/page.tsx
+++ b/web/src/pages/page.tsx
@@ -52,7 +52,7 @@ const Page: React.FC<Props> = props => {
 			<Hero
 				angleDirection="<"
 				anglePosition="after"
-				height="50vh"
+				height="500px"
 				color={[theme.color.main.purple]}
 				imageUrl={
 					urlFor(page.header.no.image)

--- a/web/src/pages/page.tsx
+++ b/web/src/pages/page.tsx
@@ -23,6 +23,12 @@ const hero = css`
 	}
 `;
 
+const body = css`
+	margin: 5vh auto 3rem auto;
+	width: 90vw;
+	max-width: 720px;
+`;
+
 type Props = { slug?: string } & RouteComponentProps;
 
 const Page: React.FC<Props> = props => {
@@ -53,9 +59,11 @@ const Page: React.FC<Props> = props => {
 				<h2>{page.header.no.title}</h2>
 				<p>{page.header.no.subtitle}</p>
 			</Hero>
-			{page.blocks.no.map(block => (
-				<Block key={block._key} block={block} />
-			))}
+			<div css={body}>
+				{page.blocks.no.map(block => (
+					<Block key={block._key} block={block} />
+				))}
+			</div>
 		</>
 	);
 };

--- a/web/src/pages/page.tsx
+++ b/web/src/pages/page.tsx
@@ -18,7 +18,7 @@ const hero = css`
 	}
 
 	p {
-		font-size: 1rem;
+		font-size: 1.1rem;
 		margin: 0;
 	}
 `;
@@ -26,7 +26,12 @@ const hero = css`
 const body = css`
 	margin: 5vh auto 3rem auto;
 	width: 90vw;
-	max-width: 720px;
+	max-width: 900px;
+
+	p {
+		font-size: 1.1rem;
+		margin: 0;
+	}
 `;
 
 type Props = { slug?: string } & RouteComponentProps;
@@ -48,13 +53,14 @@ const Page: React.FC<Props> = props => {
 				angleDirection="<"
 				anglePosition="after"
 				height="50vh"
-				color={theme.color.main.purple}
+				color={[theme.color.main.purple]}
 				imageUrl={
 					urlFor(page.header.no.image)
 						.width(window.innerWidth)
 						.url() || ""
 				}
 				css={hero}
+				textPosition="center"
 			>
 				<h2>{page.header.no.title}</h2>
 				<p>{page.header.no.subtitle}</p>


### PR DESCRIPTION
**Related issue:**
https://github.com/oslopride/oslopride.no/issues/78

**What's included:**
- Responsive fixes:
   - Text inside the menu is made slightly smaller on mobile
   - Padding inside menu made smaller on mobile
   - Hero image made vertically responsive, text below no longer overflows when making browser smaller
- Consistency fixes:
   - All main body content has a width of 90vw, centered in the middle of the page (capped at 720px)
- Accessibility fixes:
   - ARIA attributes added to the menu button (aria-haspopup, aria-controls, aria-expanded)
   - Autofocus on the close/open button when interacting with the menu
   - Disable reading the menu items when menu is collapsed
   - Documentation: https://knowbility.org/blog/2020/accessible-slide-menus/ & https://www.w3.org/TR/wai-aria-practices-1.1/#menubutton
- Other fixes:
   - Made logo clickable -> sends you to the homepage

**Note** - I suggest we repeat a clean-up task like this before the weekend after the remaining issues are merged as well (I should have time for this). Also creating a separate task for a11y improvements.

**Screenshots**
<img width="1673" alt="Screen Shot 2020-05-27 at 00 14 00" src="https://user-images.githubusercontent.com/10811350/82955426-1ba34700-9faf-11ea-98ff-83d13b6314f8.png">
<img width="1671" alt="Screen Shot 2020-05-27 at 00 14 21" src="https://user-images.githubusercontent.com/10811350/82955427-1e9e3780-9faf-11ea-9383-62c0dbba1617.png">
<img width="1669" alt="Screen Shot 2020-05-27 at 00 14 31" src="https://user-images.githubusercontent.com/10811350/82955432-22ca5500-9faf-11ea-8970-8de8e1bb39e5.png">
<img width="1674" alt="Screen Shot 2020-05-27 at 00 14 47" src="https://user-images.githubusercontent.com/10811350/82955440-25c54580-9faf-11ea-80e3-ff15afcd6ebc.png">
