### PR TITLE
add simple open graph SEO

### DIFF
--- a/web/package.json
+++ b/web/package.json
@@ -25,6 +25,7 @@
     "polished": "^3.4.4",
     "react": "^16.13.1",
     "react-dom": "^16.12.0",
+    "react-helmet": "^6.0.0",
     "react-hot-loader": "^4.12.19",
     "swr": "^0.1.18",
     "webfontloader": "^1.6.28"
@@ -42,6 +43,7 @@
     "@types/reach__router": "^1.3.0",
     "@types/react": "^16.9.22",
     "@types/react-dom": "^16.9.5",
+    "@types/react-helmet": "^6.0.0",
     "@types/webfontloader": "^1.6.29",
     "@typescript-eslint/eslint-plugin": "^2.20.0",
     "@typescript-eslint/parser": "^2.20.0",

--- a/web/src/components/seo.tsx
+++ b/web/src/components/seo.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import { Helmet } from "react-helmet";
+
+type OpenGraphProps = {
+	title: string;
+	description: string;
+	url: string;
+	locale: "nb_NO" | "en_US";
+	image: {
+		url: string;
+		alt: string;
+	};
+} & (
+	| {
+			type: "website";
+	  }
+	| {
+			type: "article";
+			publishedAt: string;
+			modifiedAt: string;
+	  }
+);
+
+type Props = {
+	openGraph: OpenGraphProps;
+};
+
+const Seo: React.FC<Props> = props => {
+	return (
+		<Helmet>
+			<title>Oslo Pride | {props.openGraph.title}</title>
+			<link rel="canonical" href="http://www.oslopride.no" />
+			<meta name="description" content={props.openGraph.description} />
+			<meta name="twitter:card" content="summary_large_image" />
+			<meta property="og:locale" content={props.openGraph.locale} />
+			<meta
+				property="og:title"
+				content={`Oslo Pride | ${props.openGraph.title}`}
+			/>
+			<meta property="og:description" content={props.openGraph.description} />
+			<meta property="og:url" content={props.openGraph.url} />
+			<meta property="og:site_name" content="Oslo Pride" />
+			<meta property="og:image" content={props.openGraph.image.url} />
+			<meta property="og:image:alt" content={props.openGraph.image.alt} />
+			<meta property="og:type" content={props.openGraph.type} />
+			{props.openGraph.type === "article" && (
+				<>
+					<meta
+						property="og:article:published_time"
+						content={props.openGraph.publishedAt}
+					/>
+					<meta
+						property="og:article:modified_time"
+						content={props.openGraph.modifiedAt}
+					/>
+				</>
+			)}
+		</Helmet>
+	);
+};
+
+export default Seo;

--- a/web/src/pages/article-overview.tsx
+++ b/web/src/pages/article-overview.tsx
@@ -7,6 +7,7 @@ import { urlFor } from "../sanity";
 import useSWR from "swr";
 import { SanityArchive, SanityArticleList } from "../sanity/models";
 import BlockContentToReact from "@sanity/block-content-to-react";
+import Seo from "../components/seo";
 
 type Props = { slug?: string } & RouteComponentProps;
 
@@ -146,6 +147,23 @@ const ArticleOverview: React.FC<Props> = () => {
 					<p>No articles yet</p>
 				)}
 			</div>
+
+			<Seo
+				openGraph={{
+					type: "website",
+					title: archive.title.no,
+					description: archive.subtitle.no,
+					url: `https://www.oslopride.no/articles`,
+					locale: "nb_NO",
+					image: {
+						url:
+							urlFor(archive.image)
+								.width(1200)
+								.url() || "",
+						alt: archive.subtitle.no
+					}
+				}}
+			/>
 		</>
 	);
 };

--- a/web/src/pages/article.tsx
+++ b/web/src/pages/article.tsx
@@ -6,8 +6,8 @@ import Hero from "../components/hero";
 import theme from "../utils/theme";
 import { urlFor } from "../sanity";
 import { css } from "@emotion/core";
-import Block from "../blocks";
 import BlockContentToReact from "@sanity/block-content-to-react";
+import Seo from "../components/seo";
 
 type Props = { slug?: string } & RouteComponentProps;
 
@@ -58,16 +58,16 @@ const credits = css`
 	line-height: 1.75rem;
 `;
 
-const Page: React.FC<Props> = props => {
+const Article: React.FC<Props> = props => {
 	const { slug } = props;
 
-	const { data: page, error } = useSWR<SanityArticle>(
+	const { data: article, error } = useSWR<SanityArticle>(
 		`*[_type == "article" && slug.current == "${slug}"] | order(_updatedAt desc) [0]`
 	);
 
 	if (error) return <div>{JSON.stringify(error)}</div>;
-	if (page === undefined) return <div>Loading...</div>;
-	if (page === null) return <div>404 - Not found</div>;
+	if (article === undefined) return <div>Loading...</div>;
+	if (article === null) return <div>404 - Not found</div>;
 
 	return (
 		<>
@@ -77,24 +77,43 @@ const Page: React.FC<Props> = props => {
 				height="500px"
 				color={[theme.color.main.purple]}
 				imageUrl={
-					urlFor(page.image)
+					urlFor(article.image)
 						.width(window.innerWidth)
 						.url() || ""
 				}
 				css={hero}
 			>
-				<p css={date}>{page._createdAt.split("T")[0]}</p>
-				<h2>{page.title.no}</h2>
-				<BlockContentToReact blocks={page.credits?.no} css={credits} />
+				<p css={date}>{article._createdAt.split("T")[0]}</p>
+				<h2>{article.title.no}</h2>
+				<BlockContentToReact blocks={article.credits?.no} />
 			</Hero>
 			<div css={[body, intro]}>
-				<BlockContentToReact blocks={page.intro?.no} />
+				<BlockContentToReact blocks={article.intro?.no} />
 			</div>
 			<div css={body}>
-				<BlockContentToReact blocks={page.body.no} />
+				<BlockContentToReact blocks={article.body.no} />
 			</div>
+
+			<Seo
+				openGraph={{
+					type: "article",
+					title: article.title.no,
+					description: article.title.no, // TODO: Either intro must be converted to a string, or we need to add a string in sanity for this field
+					url: `https://www.oslopride.no/article/${slug}`,
+					locale: "nb_NO",
+					publishedAt: article._createdAt,
+					modifiedAt: article._updatedAt,
+					image: {
+						url:
+							urlFor(article.image)
+								.width(1200)
+								.url() || "",
+						alt: article.title.no
+					}
+				}}
+			/>
 		</>
 	);
 };
 
-export default Page;
+export default Article;

--- a/web/src/pages/front-page.tsx
+++ b/web/src/pages/front-page.tsx
@@ -13,6 +13,7 @@ import useConfig from "../utils/use-config";
 import { ClientError, ServerError } from "@sanity/client";
 import Advertisement from "../blocks/advertisement";
 import FeaturedArticles from "../blocks/featured-articles";
+import Seo from "../components/seo";
 
 const date = css`
 	font-size: 1rem;
@@ -122,6 +123,22 @@ const FrontPage: React.FC<Props> = () => {
 					<FeaturedArticles content={data.featuredArticles} />
 				)}
 			</div>
+			<Seo
+				openGraph={{
+					title: "Hjem",
+					description: data.header.no.subtitle,
+					image: {
+						url:
+							urlFor(data.header.no.image)
+								.width(1200)
+								.url() || "",
+						alt: data.header.no.subtitle
+					},
+					locale: "nb_NO",
+					type: "website",
+					url: "https://www.oslopride.no"
+				}}
+			/>
 		</>
 	);
 };

--- a/web/src/pages/page.tsx
+++ b/web/src/pages/page.tsx
@@ -7,6 +7,7 @@ import Hero from "../components/hero";
 import { css } from "@emotion/core";
 import theme from "../utils/theme";
 import useSWR from "swr";
+import Seo from "../components/seo";
 
 const hero = css`
 	color: #ffffff;
@@ -70,6 +71,25 @@ const Page: React.FC<Props> = props => {
 					<Block key={block._key} block={block} />
 				))}
 			</div>
+			{page.blocks.no.map(block => (
+				<Block key={block._key} block={block} />
+			))}
+			<Seo
+				openGraph={{
+					type: "website",
+					title: page.header.no.title,
+					description: page.header.no.subtitle,
+					url: `https://www.oslopride.no/${slug}`,
+					locale: "nb_NO",
+					image: {
+						url:
+							urlFor(page.header.no.image)
+								.width(1200)
+								.url() || "",
+						alt: page.header.no.subtitle
+					}
+				}}
+			/>
 		</>
 	);
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1854,6 +1854,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-helmet@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@types/react-helmet/-/react-helmet-6.0.0.tgz#5b74e44a12662ffb12d1c97ee702cf4e220958cf"
+  integrity sha512-NBMPAxgjpaMooXa51cU1BTgrX6T+hQbMiLm77JhBbfOzPQea3RB5rNpPOD5xGWHIVpGXHd59cltEzIq0qglGcQ==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@^16.9.22":
   version "16.9.23"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.23.tgz#1a66c6d468ba11a8943ad958a8cb3e737568271c"
@@ -9379,7 +9386,7 @@ react-dom@^16.12.0, react-dom@^16.2:
     prop-types "^15.6.2"
     scheduler "^0.19.0"
 
-react-fast-compare@^2.0.2:
+react-fast-compare@^2.0.2, react-fast-compare@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
@@ -9388,6 +9395,16 @@ react-frame-component@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/react-frame-component/-/react-frame-component-4.1.1.tgz#ea8f7c518ef6b5ad72146dd1f648752369826894"
   integrity sha512-NfJp90AvYA1R6+uSYafQ+n+UM2HjHqi4WGHeprVXa6quU9d8o6ZFRzQ36uemY82dlkZFzf2jigFx6E4UzNFajA==
+
+react-helmet@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-6.0.0.tgz#fcb93ebaca3ba562a686eb2f1f9d46093d83b5f8"
+  integrity sha512-My6S4sa0uHN/IuVUn0HFmasW5xj9clTkB9qmMngscVycQ5vVG51Qp44BEvLJ4lixupTwDlU9qX1/sCrMN4AEPg==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.7.2"
+    react-fast-compare "^2.0.4"
+    react-side-effect "^2.1.0"
 
 react-hot-loader@^4.12.11, react-hot-loader@^4.12.19:
   version "4.12.19"
@@ -9522,6 +9539,11 @@ react-props-stream@^1.0.0:
   integrity sha512-LU49rWyoqVwKhZABoziAHCkc0yaCQB3y2g6aOqXNPnArN74agNcQJVP/Kmv38WlL9DblNjC+YGBBrwn/x1Oa7A==
   dependencies:
     recompose "^0.30.0"
+
+react-side-effect@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-2.1.0.tgz#1ce4a8b4445168c487ed24dab886421f74d380d3"
+  integrity sha512-IgmcegOSi5SNX+2Snh1vqmF0Vg/CbkycU9XZbOHJlZ6kMzTmi3yc254oB1WCkgA7OQtIAoLmcSFuHTc/tlcqXg==
 
 react-sortable-hoc@^0.6.3:
   version "0.6.8"


### PR DESCRIPTION
This adds simple open graph support to all pages. We still should add some [google specific structured data (JSON-LD)](https://developers.google.com/search/docs/guides/search-gallery) to get good google search results, but it's not that important (we didn't use it that much last year).

The only problem is the description field for articles. The Sanity `intro` field is block content, which makes it unusable for SEO purposes (google will crawl it of course, but facebook etc will not know that this is what we want to display when pages are shared). We need to either add another field, or change the intro field to be a simple string field.

Closes #84 