### PR TITLE
Headliners-support for front-page

### DIFF
--- a/web/src/blocks/headliners.tsx
+++ b/web/src/blocks/headliners.tsx
@@ -142,7 +142,7 @@ const SimpleEventCard: React.FC<EventCardProps> = props => {
 const Headliners: React.FC<Props> = props => {
 	const { content, featuredEvents } = props;
 
-	const hasFeaturedEvents = featuredEvents.length > 0;
+	const hasFeaturedEvents = !!featuredEvents?.length;
 
 	return (
 		<div css={headlinersContainer}>

--- a/web/src/blocks/headliners.tsx
+++ b/web/src/blocks/headliners.tsx
@@ -1,0 +1,183 @@
+import React from "react";
+import {
+	Locale,
+	SanityObject,
+	SanityObjectArray,
+	SanitySimpleEvent
+} from "../sanity/models";
+import SubHeading from "../components/sub-heading";
+import { css } from "@emotion/core";
+import { urlFor } from "../sanity";
+import BlockContentToReact from "@sanity/block-content-to-react";
+import { LinkButton } from "../components/link";
+
+type EventCardProps = {
+	content: SanitySimpleEvent;
+};
+
+type Props = {
+	content: Locale<
+		SanityObjectArray<
+			SanityObject<
+				"headliner",
+				{
+					title?: string;
+					subtitle?: string;
+				}
+			>
+		>
+	>;
+	featuredEvents: SanityObjectArray<SanitySimpleEvent>;
+};
+
+const lineCss = css`
+	margin: 2rem 0;
+`;
+
+const buttonCenter = css`
+	margin: 90px 0;
+`;
+
+const headlinersContainer = () => css`
+	text-align: center;
+	margin-bottom: 125px;
+`;
+
+const headlinersStyle = (hasAttachedEvents: boolean) => css`
+	position: relative;
+	z-index: -2;
+	margin-top: -400px;
+	padding-top: 400px;
+	padding-bottom: ${hasAttachedEvents ? "250px" : "100px"};
+	background-color: #3a1b7b;
+	text-align: center;
+	color: white;
+
+	h2 {
+		font-size: 3rem;
+		line-height: 3.5rem;
+		margin: 1rem 0;
+	}
+
+	p {
+		font-size: 1rem;
+		line-height: 1.75rem;
+		margin: 1rem 0;
+	}
+`;
+
+const featuredEventsContainer = () => css`
+	max-width: 1200px;
+	margin: -200px 1rem 3rem 1rem;
+
+	@media (min-width: 600px) {
+		margin: -200px auto 5rem auto;
+		display: flex;
+		flex-flow: row wrap;
+	}
+	align-content: flex-start;
+	justify-content: space-between;
+`;
+
+const eventItem = css`
+	text-align: left;
+	margin: 1rem 0;
+	@media (min-width: 600px) {
+		margin: 1rem;
+		flex: 0.5 1 0px;
+	}
+	display: flex;
+	flex-direction: column;
+	background-color: #f7f8fa;
+	min-height: 330px;
+`;
+
+const image = (image: string) => css`
+	height: 200px;
+	display: flex;
+	flex-direction: column-reverse;
+	align-items: flex-end;
+
+	@media (min-width: 600px) {
+		height: 220px;
+	}
+	background-image: url(${image});
+	background-size: cover;
+	background-position: center center;
+`;
+
+const eventBody = css`
+	padding: 1.5rem;
+	flex-grow: 1;
+
+	h3 {
+		margin: 0;
+	}
+
+	p {
+		font-size: 1rem;
+	}
+`;
+
+const SimpleEventCard: React.FC<EventCardProps> = props => {
+	const { content } = props;
+
+	return (
+		<article css={eventItem} key={content._id}>
+			<div
+				css={image(
+					urlFor(content.image)
+						.width(window.innerWidth)
+						.url() || ""
+				)}
+			/>
+			<div css={eventBody}>
+				<h3>{content.title.no}</h3>
+				<BlockContentToReact blocks={content.description.no} />
+			</div>
+		</article>
+	);
+};
+
+const Headliners: React.FC<Props> = props => {
+	const { content, featuredEvents } = props;
+
+	const hasFeaturedEvents = featuredEvents.length > 0;
+
+	return (
+		<div css={headlinersContainer}>
+			<section css={headlinersStyle(hasFeaturedEvents)}>
+				{content.no.map((item, _idx) => (
+					<article key={_idx}>
+						<h2>{item.title}</h2>
+						<p>{item.subtitle}</p>
+						{_idx + 1 < content.no.length && (
+							<SubHeading css={lineCss} line="line-only" />
+						)}
+					</article>
+				))}
+			</section>
+
+			{hasFeaturedEvents && (
+				<>
+					<div css={featuredEventsContainer}>
+						{featuredEvents.map((event, _idx) => (
+							<SimpleEventCard key={_idx} content={event} />
+						))}
+					</div>
+
+					<LinkButton
+						css={buttonCenter}
+						link={{
+							_type: "externalLink",
+							text: "Se alle arrangementer",
+							url: "/events"
+						}}
+					/>
+				</>
+			)}
+		</div>
+	);
+};
+
+export default Headliners;

--- a/web/src/components/header.tsx
+++ b/web/src/components/header.tsx
@@ -20,6 +20,7 @@ const headerStyle = (fixedHeader: boolean) => css`
 	position: fixed;
 	top: 0;
 	left: 0;
+	z-index: 10;
 
 	background-color: ${fixedHeader ? "#fff" : "transparent"};
 

--- a/web/src/components/hero.tsx
+++ b/web/src/components/hero.tsx
@@ -24,6 +24,7 @@ const image = (height: string) => css`
 `;
 
 const defaultContent = css`
+	position: relative;
 	width: 90vw;
 	max-width: 900px;
 	margin-left: 8rem;

--- a/web/src/components/sub-heading.tsx
+++ b/web/src/components/sub-heading.tsx
@@ -11,7 +11,7 @@ const lineCss = css`
 	place-self: center;
 `;
 
-export type SubHeadingProps = { line: "left" | "right" | "both" };
+export type SubHeadingProps = { line: "left" | "right" | "both" | "line-only" };
 
 const SubHeading = styled.span<SubHeadingProps>`
 	display: inline-flex;
@@ -35,6 +35,14 @@ const SubHeading = styled.span<SubHeadingProps>`
 			::after {
 				${lineCss}
 				margin-left: 1em;
+			}
+		`}
+		
+	${({ line }) =>
+		line === "line-only" &&
+		css`
+			::after {
+				${lineCss}
 			}
 		`}
 `;

--- a/web/src/pages/front-page.tsx
+++ b/web/src/pages/front-page.tsx
@@ -17,6 +17,7 @@ import Seo from "../components/seo";
 import PartnerPreview, {
 	DereferencedSanityPartner
 } from "../blocks/partner-preview";
+import Headliners from "../blocks/headliners";
 
 const date = css`
 	font-size: 1rem;
@@ -84,6 +85,7 @@ const FrontPage: React.FC<Props> = () => {
 		`*[_id in ["global_frontPage", "drafts.global_frontPage"]] | order(_updatedAt desc) [0]
 		{...,
 		featuredArticles[]->{image, slug, title, _createdAt},
+		featuredEvents[]->{image, title, description},
 		"partners": *[_type == "partner"]{image, name, url, type->{name, ordinal}}
 		}`
 	);
@@ -128,6 +130,12 @@ const FrontPage: React.FC<Props> = () => {
 					))}
 				</ul>
 			</Hero>
+			{data.headliners.no.length > 0 && (
+				<Headliners
+					content={data.headliners}
+					featuredEvents={data.featuredEvents}
+				/>
+			)}
 			{data.callToAction && <Advertisement content={data.callToAction.no} />}
 			<div css={body}>
 				{data.featuredArticles && (

--- a/web/src/pages/front-page.tsx
+++ b/web/src/pages/front-page.tsx
@@ -130,7 +130,7 @@ const FrontPage: React.FC<Props> = () => {
 					))}
 				</ul>
 			</Hero>
-			{data.headliners.no.length > 0 && (
+			{data.headliners?.no?.length > 0 && (
 				<Headliners
 					content={data.headliners}
 					featuredEvents={data.featuredEvents}

--- a/web/src/sanity/models.ts
+++ b/web/src/sanity/models.ts
@@ -163,7 +163,7 @@ export type SanitySimpleEvent = SanityDocument<
 		official: boolean;
 		title: Locale<string>;
 		image: SanityImage;
-		description: SanityBlockContent;
+		description: Locale<SanityBlockContent>;
 		occurance: Locale<string>;
 		price: Locale<string>;
 		eventLink: string;


### PR DESCRIPTION
- Has to have at least one headliner to appear.
- Featured events are optional

Responsive, but the front-page might need another touch-up to look good on large screens now that more components have been added.

Resolves #75

<img width="1436" alt="headliners" src="https://user-images.githubusercontent.com/13022/83305034-41735a80-a200-11ea-957c-44e99ce014f9.png">

<img width="1440" alt="no-events" src="https://user-images.githubusercontent.com/13022/83305040-446e4b00-a200-11ea-9107-4cb02c1b3731.png">
<img width="1438" alt="featured-events" src="https://user-images.githubusercontent.com/13022/83305027-3caea680-a200-11ea-9358-7988408df27b.png">


<img width="372" alt="mobile-1" src="https://user-images.githubusercontent.com/13022/83305037-43d5b480-a200-11ea-9e82-6066c1a7cc16.png">


<img width="379" alt="mobile-2" src="https://user-images.githubusercontent.com/13022/83305039-43d5b480-a200-11ea-9dfc-78454bbfbf12.png">



