### PR TITLE
Add a11y linting

### DIFF
--- a/web/.eslintrc
+++ b/web/.eslintrc
@@ -1,31 +1,33 @@
 {
-  "env": {
-    "browser": true,
-    "es6": true
-  },
-  "extends": [
-    "standard",
-    "standard-react",
+	"env": {
+		"browser": true,
+		"es6": true
+	},
+	"extends": [
+		"standard",
+		"standard-react",
     "plugin:@typescript-eslint/recommended",
-    "prettier/@typescript-eslint",
-    "plugin:prettier/recommended",
-    "prettier/react"
-  ],
-  "parser": "@typescript-eslint/parser",
-  "parserOptions": {
-    "ecmaFeatures": {
-      "jsx": true
-    },
-    "ecmaVersion": 11,
-    "sourceType": "module"
-  },
-  "settings": {
-    "react": {
-      "version": "detect"
-    }
-  },
-  "rules": {
-    "react/prop-types": "off",
-    "@typescript-eslint/explicit-function-return-type": "off"
-  }
+    "plugin:jsx-a11y/recommended",
+		"prettier/@typescript-eslint",
+		"plugin:prettier/recommended",
+		"prettier/react"
+	],
+	"plugins": ["jsx-a11y"],
+	"parser": "@typescript-eslint/parser",
+	"parserOptions": {
+		"ecmaFeatures": {
+			"jsx": true
+		},
+		"ecmaVersion": 11,
+		"sourceType": "module"
+	},
+	"settings": {
+		"react": {
+			"version": "detect"
+		}
+	},
+	"rules": {
+		"react/prop-types": "off",
+		"@typescript-eslint/explicit-function-return-type": "off"
+	}
 }

--- a/web/package.json
+++ b/web/package.json
@@ -13,6 +13,7 @@
     "dev:preview": "cross-env SANITY_PREVIEW=true yarn dev",
     "build": "cross-env NODE_ENV=production webpack -p --mode=production",
     "build:preview": "cross-env SANITY_PREVIEW=true yarn build",
+    "lint": "eslint ./src --ext .ts,.tsx",
     "type-check": "tsc"
   },
   "dependencies": {
@@ -62,6 +63,7 @@
     "eslint-config-standard": "^14.1.0",
     "eslint-config-standard-react": "^9.2.0",
     "eslint-plugin-import": "^2.20.1",
+    "eslint-plugin-jsx-a11y": "^6.3.1",
     "eslint-plugin-node": "^11.0.0",
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-promise": "^4.2.1",

--- a/web/src/blocks/collapsible.tsx
+++ b/web/src/blocks/collapsible.tsx
@@ -21,6 +21,16 @@ const CollapsibleList: React.FC<Props> = ({
 		setActive(index === active ? null : index);
 	};
 
+	// trigger key handler if key pressed is Enter or Space
+	const onKeyHandler = (
+		event: React.KeyboardEvent<HTMLHeadingElement>,
+		index: number
+	): void => {
+		if (["Enter", " "].includes(event.key)) {
+			setActive(index === active ? null : index);
+		}
+	};
+
 	const { white, black } = theme.color.text;
 	const purple = theme.color.main.purple;
 	const lightPurple = theme.color.background.purple;
@@ -43,29 +53,38 @@ const CollapsibleList: React.FC<Props> = ({
 					const Icon = isActive ? Minus : Plus;
 					return (
 						<li key={`${idx}-${item.title}`} ref={itemRefs[idx]}>
-							<h3
-								css={css`
-									display: flex;
-									justify-content: space-between;
-									align-items: center;
-									background-color: ${isActive ? purple : lightPurple};
-									color: ${isActive ? white : black};
-									padding: 15px;
-									margin: 5px 0;
-									cursor: pointer;
-								`}
-								onClick={() => onClickHandler(idx)}
-							>
-								{item.title}
-								<Icon
-									height="1em"
-									width="1em"
-									css={css`
-										stroke: ${isActive ? white : purple};
-									`}
-								/>
-							</h3>
 							<div
+								onClick={() => onClickHandler(idx)}
+								onKeyDown={event => onKeyHandler(event, idx)}
+								role="button"
+								aria-controls={`${item.title}-content`}
+								aria-expanded={isActive}
+								tabIndex={0}
+							>
+								<h3
+									css={css`
+										display: flex;
+										justify-content: space-between;
+										align-items: center;
+										background-color: ${isActive ? purple : lightPurple};
+										color: ${isActive ? white : black};
+										padding: 15px;
+										margin: 5px 0;
+										cursor: pointer;
+									`}
+								>
+									{item.title}
+									<Icon
+										height="1em"
+										width="1em"
+										css={css`
+											stroke: ${isActive ? white : purple};
+										`}
+									/>
+								</h3>
+							</div>
+							<div
+								id={`${item.title}-content`}
 								css={css`
 									padding: 3px 15px;
 									visibility: ${isActive ? "visible" : "hidden"};

--- a/web/src/blocks/partner-list.tsx
+++ b/web/src/blocks/partner-list.tsx
@@ -102,6 +102,7 @@ const PartnerList: FC<Props> = ({ content }) => {
 												.width(200)
 												.url() || undefined
 										}
+										alt={`${partner.name} logo`}
 									/>
 								))}
 						</div>
@@ -116,6 +117,7 @@ const PartnerList: FC<Props> = ({ content }) => {
 												.width(200)
 												.url() || undefined
 										}
+										alt={`${partner.name} logo`}
 									/>
 								</ImgWrap>
 								<ContentWrap>

--- a/web/src/components/header.tsx
+++ b/web/src/components/header.tsx
@@ -231,8 +231,8 @@ const Header: React.FC<Props> = () => {
 				</button>
 				<ul>
 					{navigationBar?.map(item => (
-						<li key={item._key} onClick={toggleNavigation}>
-							<Link link={item} />
+						<li key={item._key}>
+							<Link link={item} onClick={toggleNavigation} />
 						</li>
 					))}
 				</ul>

--- a/web/src/components/link.tsx
+++ b/web/src/components/link.tsx
@@ -29,10 +29,16 @@ type InternalInternalLink = {
 type Props = {
 	link: SanityInternalLink | SanityExternalLink | InternalInternalLink;
 	className?: string;
-};
+} & Omit<
+	React.DetailedHTMLProps<
+		React.AnchorHTMLAttributes<HTMLAnchorElement>,
+		HTMLAnchorElement
+	>,
+	"ref"
+>;
 
 const Link: React.FC<Props> = props => {
-	const { link, className } = props;
+	const { link, className, ...anchorProps } = props;
 	const { data, error } = useSWR<
 		| SanityPage
 		| SanityFrontPage
@@ -54,6 +60,7 @@ const Link: React.FC<Props> = props => {
 				href={link.url}
 				target="_blank"
 				rel="noopener noreferrer"
+				{...anchorProps}
 			>
 				{link.text}
 			</a>
@@ -62,7 +69,12 @@ const Link: React.FC<Props> = props => {
 
 	if (link._type === "internalInternalLink") {
 		return (
-			<RouterLink className={className} css={base} to={link.url}>
+			<RouterLink
+				className={className}
+				css={base}
+				to={link.url}
+				{...anchorProps}
+			>
 				{link.text}
 			</RouterLink>
 		);
@@ -73,7 +85,7 @@ const Link: React.FC<Props> = props => {
 	// display link text while resolving data
 	if (data === undefined) {
 		return (
-			<a className={className} css={base} href="#">
+			<a className={className} css={base} href="#" {...anchorProps}>
 				{link.text}
 			</a>
 		);
@@ -103,7 +115,7 @@ const Link: React.FC<Props> = props => {
 	}
 
 	return (
-		<RouterLink className={className} css={base} to={url}>
+		<RouterLink className={className} css={base} to={url} {...anchorProps}>
 			{link.text}
 		</RouterLink>
 	);

--- a/web/src/components/link.tsx
+++ b/web/src/components/link.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/anchor-is-valid */
 import React from "react";
 import { Link as RouterLink } from "@reach/router";
 import {
@@ -69,6 +70,7 @@ const Link: React.FC<Props> = props => {
 
 	if (error) return <span>[broken link]</span>;
 	if (data === null) return <span>[broken link]</span>;
+	// display link text while resolving data
 	if (data === undefined) {
 		return (
 			<a className={className} css={base} href="#">

--- a/web/src/components/loading.tsx
+++ b/web/src/components/loading.tsx
@@ -18,7 +18,15 @@ const Loading: React.FC<{}> = () => {
 		return () => clearTimeout(timer);
 	}, []);
 
-	return <div css={wrapper}>{showRainbows && <span>🏳️‍🌈</span>}</div>;
+	return (
+		<div css={wrapper}>
+			{showRainbows && (
+				<span role="img" aria-label="Pride flag">
+					🏳️‍🌈
+				</span>
+			)}
+		</div>
+	);
 };
 
 export default Loading;

--- a/web/src/pages/error.tsx
+++ b/web/src/pages/error.tsx
@@ -49,13 +49,28 @@ const ErrorPage: React.FC<Props & RouteComponentProps> = ({ error }) => {
 				textPosition="center"
 				css={hero}
 			>
-				<h1>500 - Error 🚨</h1>
+				<h1>
+					500 - Error{" "}
+					<span role="img" aria-label="Police car light">
+						🚨
+					</span>
+				</h1>
 			</Hero>
 			<div css={body}>
-				<p>Heisann, her gikk det visst i ball for oss 😧 Beklager det!</p>
+				<p>
+					Heisann, her gikk det visst i ball for oss{" "}
+					<span role="img" aria-label="Anguished face">
+						😧
+					</span>{" "}
+					Beklager det!
+				</p>
 				<p>
 					Alle feil blir automatisk rapportert inn, så alle varsellapene våre
-					uler nok nå 🚨 Vi fikser det så fort vi greier!
+					uler nok nå{" "}
+					<span role="img" aria-label="Police car light">
+						🚨
+					</span>{" "}
+					Vi fikser det så fort vi greier!
 				</p>
 			</div>
 		</>

--- a/web/src/pages/not-found.tsx
+++ b/web/src/pages/not-found.tsx
@@ -44,7 +44,12 @@ const NotFound: React.FC<RouteComponentProps> = () => {
 				<h1>404 - Siden finnes ikke</h1>
 			</Hero>
 			<div css={body}>
-				<p>Siden du leter etter finnes dessverre ikke 😿</p>
+				<p>
+					Siden du leter etter finnes dessverre ikke{" "}
+					<span role="img" aria-label="Crying cat">
+						😿
+					</span>
+				</p>
 			</div>
 		</>
 	);

--- a/yarn.lock
+++ b/yarn.lock
@@ -798,12 +798,27 @@
     pirates "^4.0.0"
     source-map-support "^0.5.16"
 
+"@babel/runtime-corejs3@^7.10.2":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz#02c3029743150188edeb66541195f54600278419"
+  integrity sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==
+  dependencies:
+    core-js-pure "^3.0.0"
+    regenerator-runtime "^0.13.4"
+
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.2.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.4.tgz#d79f5a2040f7caa24d53e563aad49cbc05581308"
   integrity sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==
   dependencies:
     regenerator-runtime "^0.13.2"
+
+"@babel/runtime@^7.10.2":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
+  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
 
 "@babel/template@^7.8.3", "@babel/template@^7.8.6":
   version "7.8.6"
@@ -2771,6 +2786,14 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+aria-query@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
+  integrity sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+    "@babel/runtime-corejs3" "^7.10.2"
+
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
@@ -2884,6 +2907,11 @@ assign-symbols@^1.0.0:
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
 
+ast-types-flow@^0.0.7:
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/ast-types-flow/-/ast-types-flow-0.0.7.tgz#f70b735c6bca1a5c9c22d982c3e39e7feba3bdad"
+  integrity sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
+
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
@@ -2957,6 +2985,16 @@ aws4@^1.8.0:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
   integrity sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
+
+axe-core@^3.5.4:
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-3.5.5.tgz#84315073b53fa3c0c51676c588d59da09a192227"
+  integrity sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==
+
+axobject-query@^2.1.2:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
+  integrity sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==
 
 babel-code-frame@^6.22.0, babel-code-frame@^6.26.0:
   version "6.26.0"
@@ -4082,6 +4120,11 @@ core-js-compat@^3.6.2:
     browserslist "^4.8.3"
     semver "7.0.0"
 
+core-js-pure@^3.0.0:
+  version "3.6.5"
+  resolved "https://registry.yarnpkg.com/core-js-pure/-/core-js-pure-3.6.5.tgz#c79e75f5e38dbc85a662d91eea52b8256d53b813"
+  integrity sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==
+
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
@@ -4500,6 +4543,11 @@ d@1, d@^1.0.1:
   dependencies:
     es5-ext "^0.10.50"
     type "^1.0.1"
+
+damerau-levenshtein@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/damerau-levenshtein/-/damerau-levenshtein-1.0.6.tgz#143c1641cb3d85c60c32329e26899adea8701791"
+  integrity sha512-JVrozIeElnj3QzfUIt8tB8YMluBJom4Vw9qTPpjGYQ9fYlB3D/rb6OordUxf3xeFB35LKWs0xqcO5U6ySvBtug==
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -4977,6 +5025,11 @@ emoji-regex@^8.0.0:
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-8.0.0.tgz#e818fd69ce5ccfcb404594f842963bf53164cc37"
   integrity sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
 
+emoji-regex@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-9.0.0.tgz#48a2309cc8a1d2e9d23bc6a67c39b63032e76ea4"
+  integrity sha512-6p1NII1Vm62wni/VR/cUMauVQoxmLVb9csqQlvLz+hO2gk8U2UYDfXHQSUYIBKmZwAKz867IDqG7B+u0mj+M6w==
+
 emojis-list@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-2.1.0.tgz#4daa4d9db00f9819880c79fa457ae5b09a1fd389"
@@ -5276,6 +5329,23 @@ eslint-plugin-import@^2.20.0, eslint-plugin-import@^2.20.1:
     object.values "^1.1.0"
     read-pkg-up "^2.0.0"
     resolve "^1.12.0"
+
+eslint-plugin-jsx-a11y@^6.3.1:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.3.1.tgz#99ef7e97f567cc6a5b8dd5ab95a94a67058a2660"
+  integrity sha512-i1S+P+c3HOlBJzMFORRbC58tHa65Kbo8b52/TwCwSKLohwvpfT5rm2GjGWzOHTEuq4xxf2aRlHHTtmExDQOP+g==
+  dependencies:
+    "@babel/runtime" "^7.10.2"
+    aria-query "^4.2.2"
+    array-includes "^3.1.1"
+    ast-types-flow "^0.0.7"
+    axe-core "^3.5.4"
+    axobject-query "^2.1.2"
+    damerau-levenshtein "^1.0.6"
+    emoji-regex "^9.0.0"
+    has "^1.0.3"
+    jsx-ast-utils "^2.4.1"
+    language-tags "^1.0.5"
 
 eslint-plugin-node@^11.0.0:
   version "11.0.0"
@@ -7697,6 +7767,14 @@ jsx-ast-utils@^2.2.3:
     array-includes "^3.0.3"
     object.assign "^4.1.0"
 
+jsx-ast-utils@^2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz#1114a4c1209481db06c690c2b4f488cc665f657e"
+  integrity sha512-z1xSldJ6imESSzOjd3NNkieVJKRlKYSOtMG8SFyCj2FIrvSaSuli/WjpBkEzCBoR9bYYYFgqJw61Xhu7Lcgk+w==
+  dependencies:
+    array-includes "^3.1.1"
+    object.assign "^4.1.0"
+
 killable@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892"
@@ -7732,6 +7810,18 @@ kind-of@^6.0.0, kind-of@^6.0.2:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
+language-subtag-registry@~0.3.2:
+  version "0.3.20"
+  resolved "https://registry.yarnpkg.com/language-subtag-registry/-/language-subtag-registry-0.3.20.tgz#a00a37121894f224f763268e431c55556b0c0755"
+  integrity sha512-KPMwROklF4tEx283Xw0pNKtfTj1gZ4UByp4EsIFWLgBavJltF4TiYPc39k06zSTsLzxTVXXDSpbwaQXaFB4Qeg==
+
+language-tags@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/language-tags/-/language-tags-1.0.5.tgz#d321dbc4da30ba8bf3024e040fa5c14661f9193a"
+  integrity sha1-0yHbxNowuovzAk4ED6XBRmH5GTo=
+  dependencies:
+    language-subtag-registry "~0.3.2"
 
 lazy-cache@^0.2.3:
   version "0.2.7"
@@ -10806,6 +10896,11 @@ regenerator-runtime@^0.13.3:
   version "0.13.5"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz#d878a1d094b4306d10b9096484b33ebd55e26697"
   integrity sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==
+
+regenerator-runtime@^0.13.4:
+  version "0.13.7"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz#cac2dacc8a1ea675feaabaeb8ae833898ae46f55"
+  integrity sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
 
 regenerator-transform@^0.14.0:
   version "0.14.1"


### PR DESCRIPTION
Added `eslint-plugin-jsx-a11y` to the ESLint config and tried some fixes for the few first lint errors from doing so:

- Added img role and aria-label to all emojis
- Added missing img alt tags
- Disabled valid anchor rule for the `Link` component:
```tsx
	if (data === undefined) {
		return (
			<a className={className} css={base} href="#">
				{link.text}
			</a>
		);
	}
```
I *think* in this specific case it's ok? It's just temporarily showing the link while the URL is being resolved from Sanity. Alternative is to style some text to look like a link. I'm not sure which one is better?
- Wrapped the headers for Collapsible items in a div with a button role, and added aria-expanded and aria-controls tags along with tabindex, as well as a key handler. Not 100% sure if this was the best approach?
- Moved onClick handler from the menu li element to the link inside the li

Fixes #143 