### PR TITLE
add subheading in sanity frontpage schema

### DIFF
--- a/sanity/schemas/front-page.js
+++ b/sanity/schemas/front-page.js
@@ -13,6 +13,12 @@ export default {
 				type: "object",
 				fields: [
 					{
+						name: "subHeading",
+						title: "Sub heading",
+						type: "string",
+						validation: Rule => Rule.required()
+					},
+					{
 						name: "title",
 						title: "Title",
 						type: "string",

--- a/web/src/pages/front-page.tsx
+++ b/web/src/pages/front-page.tsx
@@ -111,7 +111,7 @@ const FrontPage: React.FC<Props> = () => {
 				css={hero}
 			>
 				{width > 700 ? (
-					<SubHeading line="left">Oslo Pride</SubHeading>
+					<SubHeading line="left">{data.header.no.subHeading}</SubHeading>
 				) : (
 					<h1 css={date}>{config?.date}</h1>
 				)}

--- a/web/src/sanity/models.ts
+++ b/web/src/sanity/models.ts
@@ -62,6 +62,7 @@ export type SanityInternalLink = SanityObject<
 >;
 
 export type SanityPageHeader = Locale<{
+	subHeading: string;
 	title: string;
 	subtitle: string;
 	links?: SanityObjectArray<SanityInternalLink | SanityExternalLink>;


### PR DESCRIPTION
This makes the subheading able to be edited in Sanity.

Fixes #155 