### PR TITLE
Header styling adjustments

### DIFF
--- a/web/src/components/header.tsx
+++ b/web/src/components/header.tsx
@@ -15,7 +15,7 @@ const headerStyle = css`
 	width: 100%;
 	margin: 0 auto;
 	position: absolute;
-	top: 0;
+	top: 0.85rem;
 	left: 0;
 	z-index: 10;
 	background-color: transparent;
@@ -160,6 +160,7 @@ const buttonStyle = css`
 
 const closeButton = (close: string) => css`
 	background-image: url(${close});
+	top: 2.85rem;
 `;
 
 const hidden = css`

--- a/web/src/components/header.tsx
+++ b/web/src/components/header.tsx
@@ -46,7 +46,7 @@ const headerStyle = css`
 	p {
 		position: absolute;
 		top: 1rem;
-		right: 6rem;
+		right: 8rem;
 		text-transform: uppercase;
 		font-size: 1.2rem;
 		font-weight: 600;


### PR DESCRIPTION
- Adds more top "padding" for header
Was a little torn on doing it this way, but because of all the absolute positioning it seemed like the quickest fix to just adjust the `top` position of the header itself, and then the close button (since it is in its own div and the header position does not affect it). Is there some better way to do this? Probably, but I don't know how without completely rewriting the styling and I hate CSS :)
- Adds more space between header date and menu button

Fixes #152, fixes #151 