### PR TITLE
add hover and focus color to footer links

### DIFF
--- a/web/src/components/footer/styles.ts
+++ b/web/src/components/footer/styles.ts
@@ -23,6 +23,10 @@ export const Footer = styled.div`
 
 	a {
 		color: ${theme.color.background.pink};
+		&:hover,
+		&:focus {
+			color: ${theme.color.background.lightYellow};
+		}
 	}
 
 	a,

--- a/web/src/utils/theme.tsx
+++ b/web/src/utils/theme.tsx
@@ -6,7 +6,8 @@ const theme = {
 			white: "#f7f8fa",
 			pink: "#f7acb3",
 			purple: "#bfb4d3",
-			lightPurple: "#ebe7f1"
+			lightPurple: "#ebe7f1",
+			lightYellow: "#ffecac"
 		}
 	}
 };


### PR DESCRIPTION
Used the lighter yellow color in the XD sketch. I think it looks better than the "normal" yellow there? I also added the same color when the link is focused as well.

e.g. `#ffecac` vs `#ffc100`

Fixes #156 