### PR TITLE
add body block to frontpage

### DIFF
--- a/sanity/schemas/front-page.js
+++ b/sanity/schemas/front-page.js
@@ -43,6 +43,15 @@ export default {
 			},
 			(lang, Rule) => (lang.isDefault ? Rule.required() : undefined)
 		),
+		localize(
+			{
+				title: "Body",
+				name: "body",
+				type: "array",
+				of: [{ type: "block" }]
+			},
+			(lang, Rule) => (lang.isDefault ? Rule.required() : undefined)
+		),
 		localize({
 			title: "Headliners",
 			name: "headliners",

--- a/web/src/pages/front-page.tsx
+++ b/web/src/pages/front-page.tsx
@@ -19,6 +19,7 @@ import Headliners from "../blocks/headliners";
 import Loading from "../components/loading";
 import NotFound from "./not-found";
 import Error from "./error";
+import SanityPortableText from "../components/sanity-portable-text";
 
 const date = css`
 	font-size: 1rem;
@@ -131,6 +132,9 @@ const FrontPage: React.FC<Props> = () => {
 					))}
 				</ul>
 			</Hero>
+			<div css={body}>
+				{data.body?.no && <SanityPortableText blocks={data.body.no} />}
+			</div>
 			{data.headliners?.no?.length > 0 && (
 				<Headliners
 					content={data.headliners}

--- a/web/src/sanity/models.ts
+++ b/web/src/sanity/models.ts
@@ -179,6 +179,7 @@ export type SanitySimpleEvent = SanityDocument<
 export type SanityFrontPage = SanityDocument<
 	"frontPage",
 	{
+		body: Locale<SanityObjectArray<SanityBlock>>;
 		header: SanityPageHeader;
 		headliners: Locale<
 			SanityObjectArray<


### PR DESCRIPTION
Adds an additional body block to the frontpage for text content under hero header.

Fixes #154 