### PR TITLE
add padding to bottom of page template

### DIFF
--- a/web/src/pages/page.tsx
+++ b/web/src/pages/page.tsx
@@ -34,6 +34,7 @@ const body = css`
 	margin-left: auto;
 	margin-right: auto;
 	margin-top: 2rem;
+	padding-bottom: 5rem;
 
 	p,
 	blockquote,


### PR DESCRIPTION
The issue was for adding padding to bottom of "about us" between the content and footer. This will affect every page using the "page" template. I think this is still totally ok?

Since some pages have different styling at the bottom, we can't just simply add a top-margin to the footer itself, so every layout template will have to make its own adjustments.

I only added this to the `page` template for this issue right now, as I'm not sure if the `article` template etc. should have the exact same treatment.

Fixes #158 