### PR TITLE
add global default link color

### DIFF
--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -49,6 +49,14 @@ const globalStyles = css`
 		flex-direction: column;
 	}
 
+	a {
+		color: ${theme.color.main.purple};
+		&:hover,
+		&:focus {
+			color: ${theme.color.main.blue};
+		}
+	}
+
 	main {
 		flex: 1 0 auto;
 


### PR DESCRIPTION
Do you think using these colors is clear, it seems like the purple might be a bit too dark? But maybe having the underline makes it good enough?
`#3a1b7b` and `#184FBD` for hover.

Fixes #159 