### PR TITLE
use global text styling

### DIFF
--- a/web/src/blocks/advertisement.tsx
+++ b/web/src/blocks/advertisement.tsx
@@ -64,7 +64,6 @@ const headerStyle = () => css`
 	}
 
 	p {
-		font-size: 1rem;
 		margin: 0;
 	}
 

--- a/web/src/blocks/headliners.tsx
+++ b/web/src/blocks/headliners.tsx
@@ -73,8 +73,6 @@ const headlinersStyle = (hasAttachedEvents: boolean) => css`
 	}
 
 	p {
-		font-size: 1rem;
-		line-height: 1.75rem;
 		margin: 1rem 0;
 	}
 `;
@@ -142,7 +140,6 @@ const eventBody = css`
 
 	& div {
 		font-size: 1rem;
-		line-height: 1.3rem;
 		flex-grow: 1;
 		a {
 			color: ${theme.color.main.pink};

--- a/web/src/components/footer/styles.ts
+++ b/web/src/components/footer/styles.ts
@@ -4,7 +4,6 @@ import styled from "@emotion/styled";
 export const StickyFooter = styled.footer`
 	background-color: ${theme.color.main.purple};
 	color: ${theme.color.text.white};
-	font-size: 1rem;
 `;
 
 export const Footer = styled.div`

--- a/web/src/components/header.tsx
+++ b/web/src/components/header.tsx
@@ -48,7 +48,6 @@ const headerStyle = css`
 		top: 1rem;
 		right: 6rem;
 		text-transform: uppercase;
-		font-size: 1.2rem;
 		font-weight: 600;
 		letter-spacing: 0.5px;
 		color: #f7acb3;

--- a/web/src/components/link.tsx
+++ b/web/src/components/link.tsx
@@ -138,7 +138,6 @@ export const LinkButton = styled(Link)<LinkButtonProps>`
 	border-radius: 4px;
 	color: ${props => (props.color === "pink" ? "#2b193c" : "#ffffff")};
 	font-weight: bold;
-	font-size: 1rem;
 	transition: color 0.3s, background 0.3s;
 
 	:hover {

--- a/web/src/index.tsx
+++ b/web/src/index.tsx
@@ -51,10 +51,13 @@ const globalStyles = css`
 
 	main {
 		flex: 1 0 auto;
+	}
 
-		p {
-			font-size: 1.1rem;
-		}
+	p,
+	blockquote,
+	ul {
+		font-size: 1.1rem;
+		line-height: 1.75rem;
 	}
 
 	footer {

--- a/web/src/pages/article-overview.tsx
+++ b/web/src/pages/article-overview.tsx
@@ -24,7 +24,6 @@ const hero = css`
 	}
 
 	p {
-		font-size: 1.1rem;
 		margin: 0;
 	}
 `;

--- a/web/src/pages/article-overview.tsx
+++ b/web/src/pages/article-overview.tsx
@@ -59,11 +59,6 @@ const article = css`
 	grid-template-columns: 1fr 1fr;
 	margin-bottom: 2rem;
 
-	p {
-		font-size: 1.1rem;
-		line-height: 1.75rem;
-	}
-
 	div {
 		min-width: 50%;
 	}

--- a/web/src/pages/article.tsx
+++ b/web/src/pages/article.tsx
@@ -25,7 +25,6 @@ const hero = css`
 	}
 
 	p {
-		font-size: 1rem;
 		margin: 0;
 	}
 `;

--- a/web/src/pages/article.tsx
+++ b/web/src/pages/article.tsx
@@ -41,8 +41,6 @@ const body = css`
 	p,
 	blockquote,
 	ul {
-		font-size: 1.1rem;
-		line-height: 1.75rem;
 		margin-bottom: 2rem;
 	}
 `;

--- a/web/src/pages/error.tsx
+++ b/web/src/pages/error.tsx
@@ -12,7 +12,6 @@ const body = css`
 	max-width: 900px;
 
 	p {
-		font-size: 1.1rem;
 		margin: 0;
 	}
 `;

--- a/web/src/pages/event-overview.tsx
+++ b/web/src/pages/event-overview.tsx
@@ -27,7 +27,6 @@ const hero = css`
 	}
 
 	p {
-		font-size: 1rem;
 		margin: 0 auto;
 		@media (min-width: 600px) {
 			max-width: 50vw;

--- a/web/src/pages/event-overview.tsx
+++ b/web/src/pages/event-overview.tsx
@@ -44,8 +44,6 @@ const body = css`
 	p {
 		margin-bottom: 0;
 		color: ${theme.color.text.grey};
-		font-size: 1rem;
-		line-height: 1.3rem;
 
 		a {
 			color: ${theme.color.main.pink};

--- a/web/src/pages/front-page.tsx
+++ b/web/src/pages/front-page.tsx
@@ -36,8 +36,6 @@ const hero = css`
 	}
 
 	p {
-		font-size: 1.1rem;
-		line-height: 1.75rem;
 		margin: 0;
 	}
 

--- a/web/src/pages/front-page.tsx
+++ b/web/src/pages/front-page.tsx
@@ -67,7 +67,6 @@ const body = css`
 	max-width: 1200px;
 
 	p {
-		font-size: 1.1rem;
 		margin: 0;
 	}
 `;

--- a/web/src/pages/not-found.tsx
+++ b/web/src/pages/not-found.tsx
@@ -12,7 +12,6 @@ const body = css`
 	max-width: 900px;
 
 	p {
-		font-size: 1.1rem;
 		margin: 0;
 	}
 `;

--- a/web/src/pages/page.tsx
+++ b/web/src/pages/page.tsx
@@ -38,8 +38,6 @@ const body = css`
 	p,
 	blockquote,
 	ul {
-		font-size: 1.1rem;
-		line-height: 1.75rem;
 		margin-bottom: 2rem;
 	}
 `;

--- a/web/src/pages/page.tsx
+++ b/web/src/pages/page.tsx
@@ -22,7 +22,6 @@ const hero = css`
 	}
 
 	p {
-		font-size: 1.1rem;
 		margin: 0;
 	}
 `;

--- a/web/src/pages/partner-overview.tsx
+++ b/web/src/pages/partner-overview.tsx
@@ -27,7 +27,6 @@ const hero = css`
 	}
 
 	p {
-		font-size: 1.1rem;
 		margin: 0;
 	}
 `;


### PR DESCRIPTION
Remove a lot of "hard-coded" font-sizes and line-heights. There's still tons of others around, but I think it requires a separate cleanup to de-duplicate a lot of the common superfluous styling all over.

Fixes #140 