### PR TITLE
feat: frontpage live embed prototype

### DIFF
--- a/sanity/schemas/front-page.js
+++ b/sanity/schemas/front-page.js
@@ -6,6 +6,25 @@ export default {
 	type: "document",
 	fieldsets: [{ name: "header", title: "Header" }],
 	fields: [
+		{
+			title: "Live Embed",
+			name: "liveEmbed",
+			type: "object",
+			fields: [
+				{
+					name: "active",
+					title: "Active",
+					type: "boolean",
+					validation: Rule => Rule.required()
+				},
+				{
+					name: "embed",
+					title: "Embed",
+					type: "array",
+					of: [{ type: "youtube" }]
+				}
+			]
+		},
 		localize(
 			{
 				title: "Header",

--- a/web/src/blocks/headliners.tsx
+++ b/web/src/blocks/headliners.tsx
@@ -161,8 +161,6 @@ const descriptionContainer = css`
 const SimpleEventCard: React.FC<EventCardProps> = props => {
 	const { content } = props;
 
-	console.log(content);
-
 	const date = new Date(content.startTime).toLocaleDateString("nb-NO", {
 		weekday: "long",
 		day: "numeric",

--- a/web/src/blocks/live-embed.tsx
+++ b/web/src/blocks/live-embed.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+import { SanityLiveEmbed } from "../sanity/models";
+import YoutubeEmbed from "../components/sanity-portable-text/youtube-embed";
+
+type Props = {
+	content: SanityLiveEmbed;
+};
+
+const LiveEmbed = ({ content }: Props) => {
+	const { embed } = content;
+	if (embed.length === 0) return null;
+
+	const firstEmbed = embed[0];
+
+	switch (firstEmbed._type) {
+		case "youtube":
+			return <YoutubeEmbed node={{ url: firstEmbed.url }} />;
+		default:
+			return null;
+	}
+};
+
+export default LiveEmbed;

--- a/web/src/pages/front-page.tsx
+++ b/web/src/pages/front-page.tsx
@@ -20,6 +20,7 @@ import Loading from "../components/loading";
 import NotFound from "./not-found";
 import Error from "./error";
 import SanityPortableText from "../components/sanity-portable-text";
+import LiveEmbed from "../blocks/live-embed";
 
 const date = css`
 	font-size: 1rem;
@@ -94,6 +95,10 @@ const FrontPage: React.FC<Props> = () => {
 	if (data === undefined) return <Loading />;
 	if (data === null) return <NotFound />;
 
+	const liveEmbed = data.liveEmbed?.active && (
+		<LiveEmbed content={data.liveEmbed} />
+	);
+
 	return (
 		<>
 			<Hero
@@ -107,27 +112,32 @@ const FrontPage: React.FC<Props> = () => {
 						.url() || ""
 				}
 				css={hero}
+				textPosition={liveEmbed ? "center" : "left"}
 			>
-				{width > 700 ? (
-					<SubHeading line="left">Oslo Pride</SubHeading>
-				) : (
-					<h1 css={date}>{config?.date}</h1>
+				{liveEmbed || (
+					<>
+						{width > 700 ? (
+							<SubHeading line="left">Oslo Pride</SubHeading>
+						) : (
+							<h1 css={date}>{config?.date}</h1>
+						)}
+						<h2>{data.header.no.title}</h2>
+						<p>{data.header.no.subtitle}</p>
+						<ul>
+							{data.header.no.links?.map((link, idx) => (
+								<li key={link._key}>
+									<LinkButton
+										link={link}
+										color={idx === 0 ? "pink" : "blue"}
+										css={css`
+											width: 100%;
+										`}
+									/>
+								</li>
+							))}
+						</ul>
+					</>
 				)}
-				<h2>{data.header.no.title}</h2>
-				<p>{data.header.no.subtitle}</p>
-				<ul>
-					{data.header.no.links?.map((link, idx) => (
-						<li key={link._key}>
-							<LinkButton
-								link={link}
-								color={idx === 0 ? "pink" : "blue"}
-								css={css`
-									width: 100%;
-								`}
-							/>
-						</li>
-					))}
-				</ul>
 			</Hero>
 			<div css={body}>
 				{data.body?.no && <SanityPortableText blocks={data.body.no} />}

--- a/web/src/sanity/models.ts
+++ b/web/src/sanity/models.ts
@@ -144,6 +144,16 @@ export type SanityQuote = SanityObject<
 	}
 >;
 
+export type SanityYoutubeEmbed = SanityObject<"youtube", { url: string }>;
+
+export type SanityLiveEmbed = SanityObject<
+	"liveEmbed",
+	{
+		active: boolean;
+		embed: SanityObjectArray<SanityYoutubeEmbed>;
+	}
+>;
+
 export type SanityBlock =
 	| SanityAnnouncement
 	| SanityAdvertisement
@@ -151,7 +161,8 @@ export type SanityBlock =
 	| SanityCollapsibleList
 	| SanityPartnerPreview
 	| SanitySplitPane
-	| SanityQuote;
+	| SanityQuote
+	| SanityLiveEmbed;
 
 /**
  *
@@ -180,6 +191,7 @@ export type SanityFrontPage = SanityDocument<
 	"frontPage",
 	{
 		body: Locale<SanityObjectArray<SanityBlock>>;
+		liveEmbed: SanityLiveEmbed;
 		header: SanityPageHeader;
 		headliners: Locale<
 			SanityObjectArray<


### PR DESCRIPTION
I couldn't get any Facebook code to work, and it also requires us to have an App ID.
The structure of this was originally made with having the option of Youtube and Facebook in mind, I guess it could be simplified if we only ever use Youtube, but I think it's still ok (?).

I opted to have an `active` boolean instead of just a video(list), so one could sort of decide when to enable/disable something without having to add/remove a url multiple times. It's also currently an array, where it picks the top video to display.

If a live embed is marked as active, it will show a Youtube embed in the hero instead of the normal header. If nothing is active, then *gasp* it will do the other way around instead.

Safe to say it's very much a prototype proof of concept thing. I don't know how much more time I have this weekend to do anything better right now. Feel free to improve or trash this completely if you have some better ideas 😄  (please!)