### PR TITLE
Add new content block on front page

### DIFF
--- a/web/src/components/angled-image.tsx
+++ b/web/src/components/angled-image.tsx
@@ -1,21 +1,13 @@
 import styled from "@emotion/styled";
 
-export type angleDirection = "<" | ">";
-
 type Props = {
-	direction: angleDirection;
 	overlayColor: Array<string>;
 	imageUrl: string;
 };
 
-const getGradient = (colorList: Array<string>, direction: string) => {
+const getGradient = (colorList: Array<string>) => {
 	if (colorList.length > 1) {
-		let output = "background-image: linear-gradient(";
-		if (direction === "<") {
-			output += "190deg, ";
-		} else {
-			output += "170deg, ";
-		}
+		let output = "background-image: linear-gradient(170deg, ";
 		colorList.forEach((color, index) => {
 			output += color;
 			if (index === 0) {
@@ -47,7 +39,7 @@ const AngledImage = styled.figure<Props>`
 		right: 0;
 		bottom: 0;
 		background-color: ${props => props.overlayColor[0]};
-		${props => getGradient(props.overlayColor, props.direction)};
+		${props => getGradient(props.overlayColor)};
 		background-size: 150% 150%;
 		background-position: top left;
 		opacity: 0.85;

--- a/web/src/components/background-image.tsx
+++ b/web/src/components/background-image.tsx
@@ -24,7 +24,7 @@ const getGradient = (colorList: Array<string>) => {
 	}
 };
 
-const AngledImage = styled.figure<Props>`
+const BackgroundImage = styled.figure<Props>`
 	position: relative;
 	margin: 0;
 	background-image: url("${props => props.imageUrl}");
@@ -46,4 +46,4 @@ const AngledImage = styled.figure<Props>`
 	}
 `;
 
-export default AngledImage;
+export default BackgroundImage;

--- a/web/src/components/hero.tsx
+++ b/web/src/components/hero.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { css } from "@emotion/core";
-import AngledImage from "./angled-image";
+import BackgroundImage from "./background-image";
 import theme from "../utils/theme";
 
 const hero = (height: string) => css`
@@ -100,7 +100,7 @@ const Hero: React.FC<Props> = props => {
 
 	return (
 		<div css={hero(height)}>
-			<AngledImage
+			<BackgroundImage
 				imageUrl={imageUrl}
 				overlayColor={color}
 				css={image(height)}

--- a/web/src/components/hero.tsx
+++ b/web/src/components/hero.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { css } from "@emotion/core";
-import AngledImage, { angleDirection } from "./angled-image";
+import AngledImage from "./angled-image";
 import theme from "../utils/theme";
 
 const hero = (height: string) => css`
@@ -70,7 +70,6 @@ const centeredContent = css`
 `;
 
 type Props = {
-	angleDirection: angleDirection;
 	height: string;
 	imageUrl: string;
 	color: Array<string>;
@@ -81,14 +80,7 @@ type Props = {
 };
 
 const Hero: React.FC<Props> = props => {
-	const {
-		angleDirection,
-		height,
-		imageUrl,
-		color,
-		className,
-		children
-	} = props;
+	const { height, imageUrl, color, className, children } = props;
 
 	const contentRef = React.useRef<HTMLDivElement>(null);
 	const scrollButtonRef = React.useRef<HTMLButtonElement>(null);
@@ -109,7 +101,6 @@ const Hero: React.FC<Props> = props => {
 	return (
 		<div css={hero(height)}>
 			<AngledImage
-				direction={angleDirection}
 				imageUrl={imageUrl}
 				overlayColor={color}
 				css={image(height)}

--- a/web/src/components/hero.tsx
+++ b/web/src/components/hero.tsx
@@ -75,7 +75,7 @@ type Props = {
 	color: Array<string>;
 	overflow?: boolean;
 	className?: string;
-	textPosition?: "center" | "left";
+	centerContent?: boolean;
 	displayScrollButton?: boolean;
 };
 
@@ -83,11 +83,6 @@ const Hero: React.FC<Props> = props => {
 	const { height, imageUrl, color, className, children } = props;
 
 	const scrollButtonRef = React.useRef<HTMLButtonElement>(null);
-
-	const contentClass =
-		props.textPosition === "center"
-			? [defaultContent, centeredContent]
-			: defaultContent;
 
 	function scrollToContent(): void {
 		const buttonDistanceFromTop = scrollButtonRef.current?.offsetTop as number;
@@ -105,7 +100,9 @@ const Hero: React.FC<Props> = props => {
 				css={image(height)}
 			/>
 			<div className={className}>
-				<div css={contentClass}>{children}</div>
+				<div css={[defaultContent, props.centerContent && centeredContent]}>
+					{children}
+				</div>
 			</div>
 
 			{props.displayScrollButton && (

--- a/web/src/components/hero.tsx
+++ b/web/src/components/hero.tsx
@@ -82,7 +82,6 @@ type Props = {
 const Hero: React.FC<Props> = props => {
 	const { height, imageUrl, color, className, children } = props;
 
-	const contentRef = React.useRef<HTMLDivElement>(null);
 	const scrollButtonRef = React.useRef<HTMLButtonElement>(null);
 
 	const contentClass =
@@ -106,9 +105,7 @@ const Hero: React.FC<Props> = props => {
 				css={image(height)}
 			/>
 			<div className={className}>
-				<div css={contentClass} ref={contentRef}>
-					{children}
-				</div>
+				<div css={contentClass}>{children}</div>
 			</div>
 
 			{props.displayScrollButton && (

--- a/web/src/components/hero.tsx
+++ b/web/src/components/hero.tsx
@@ -7,6 +7,11 @@ const hero = (height: string) => css`
 	min-height: 400px;
 	height: ${height};
 	padding-top: 13rem;
+	color: #ffffff;
+
+	h2 {
+		font-size: 4rem;
+	}
 
 	@media screen and (max-width: 800px) {
 		padding-top: 8rem;

--- a/web/src/pages/article-overview.tsx
+++ b/web/src/pages/article-overview.tsx
@@ -15,11 +15,9 @@ import Error from "./error";
 type Props = { slug?: string } & RouteComponentProps;
 
 const hero = css`
-	color: #ffffff;
 	text-align: center;
 
 	h2 {
-		font-size: 4rem;
 		margin: 0 0 2rem 0;
 	}
 

--- a/web/src/pages/article-overview.tsx
+++ b/web/src/pages/article-overview.tsx
@@ -104,7 +104,6 @@ const ArticleOverview: React.FC<Props> = () => {
 	return (
 		<>
 			<Hero
-				angleDirection="<"
 				height="600px"
 				color={[theme.color.main.purple]}
 				imageUrl={

--- a/web/src/pages/article-overview.tsx
+++ b/web/src/pages/article-overview.tsx
@@ -112,7 +112,7 @@ const ArticleOverview: React.FC<Props> = () => {
 						.url() || ""
 				}
 				css={hero}
-				textPosition="center"
+				centerContent
 			>
 				<h2>{archive.title.no}</h2>
 				<p>{archive.subtitle.no}</p>

--- a/web/src/pages/article.tsx
+++ b/web/src/pages/article.tsx
@@ -62,7 +62,6 @@ const Article: React.FC<Props> = props => {
 	return (
 		<>
 			<Hero
-				angleDirection="<"
 				height="500px"
 				color={[theme.color.main.purple]}
 				imageUrl={

--- a/web/src/pages/article.tsx
+++ b/web/src/pages/article.tsx
@@ -15,12 +15,9 @@ import Error from "./error";
 type Props = { slug?: string } & RouteComponentProps;
 
 const hero = css`
-	color: #ffffff;
-	text-align: left;
 	margin-bottom: 3rem;
 
 	h2 {
-		font-size: 4rem;
 		margin: 0 0 1rem 0;
 	}
 

--- a/web/src/pages/error.tsx
+++ b/web/src/pages/error.tsx
@@ -17,7 +17,6 @@ const body = css`
 `;
 
 const hero = css`
-	color: white;
 	text-align: center;
 `;
 

--- a/web/src/pages/error.tsx
+++ b/web/src/pages/error.tsx
@@ -39,7 +39,6 @@ const ErrorPage: React.FC<Props & RouteComponentProps> = ({ error }) => {
 				<meta name="robots" content="noindex" />
 			</Helmet>
 			<Hero
-				angleDirection="<"
 				height="500px"
 				color={[theme.color.main.purple]}
 				imageUrl=""

--- a/web/src/pages/error.tsx
+++ b/web/src/pages/error.tsx
@@ -42,7 +42,7 @@ const ErrorPage: React.FC<Props & RouteComponentProps> = ({ error }) => {
 				height="500px"
 				color={[theme.color.main.purple]}
 				imageUrl=""
-				textPosition="center"
+				centerContent
 				css={hero}
 			>
 				<h1>

--- a/web/src/pages/event-overview.tsx
+++ b/web/src/pages/event-overview.tsx
@@ -269,7 +269,7 @@ const EventOverview: React.FC<Props> = () => {
 						.url() || ""
 				}
 				css={hero}
-				textPosition="center"
+				centerContent
 			>
 				<h2>{archive.title.no}</h2>
 				<p>{archive.subtitle && archive.subtitle.no}</p>

--- a/web/src/pages/event-overview.tsx
+++ b/web/src/pages/event-overview.tsx
@@ -261,7 +261,6 @@ const EventOverview: React.FC<Props> = () => {
 	return (
 		<>
 			<Hero
-				angleDirection="<"
 				height="60vh"
 				color={[theme.color.main.purple, theme.color.main.pink]}
 				imageUrl={

--- a/web/src/pages/event-overview.tsx
+++ b/web/src/pages/event-overview.tsx
@@ -18,11 +18,9 @@ import { LinkButton } from "../components/link";
 type Props = { slug?: string } & RouteComponentProps;
 
 const hero = css`
-	color: #ffffff;
 	text-align: center;
 
 	h2 {
-		font-size: 4rem;
 		margin: 0 0 2rem 0;
 	}
 

--- a/web/src/pages/front-page.tsx
+++ b/web/src/pages/front-page.tsx
@@ -28,10 +28,7 @@ const date = css`
 `;
 
 const hero = css`
-	color: #ffffff;
-
 	h2 {
-		font-size: 4rem;
 		line-height: 3.5rem;
 		margin: 2rem 0;
 	}

--- a/web/src/pages/front-page.tsx
+++ b/web/src/pages/front-page.tsx
@@ -94,7 +94,6 @@ const FrontPage: React.FC<Props> = () => {
 	return (
 		<>
 			<Hero
-				angleDirection=">"
 				height="720px"
 				color={[theme.color.main.purple, theme.color.main.pink]}
 				imageUrl={

--- a/web/src/pages/front-page.tsx
+++ b/web/src/pages/front-page.tsx
@@ -63,10 +63,11 @@ const body = css`
 	margin: 5vh auto 3rem auto;
 	width: 90vw;
 	max-width: 1200px;
+`;
 
-	p {
-		margin: 0;
-	}
+const bodyText = css`
+	max-width: clamp(20rem, 60%, 40rem);
+	margin: 6rem auto;
 `;
 
 type Props = {} & RouteComponentProps;
@@ -124,22 +125,30 @@ const FrontPage: React.FC<Props> = () => {
 					))}
 				</ul>
 			</Hero>
+
 			<div css={body}>
-				{data.body?.no && <SanityPortableText blocks={data.body.no} />}
+				{data.body?.no && (
+					<SanityPortableText blocks={data.body.no} css={bodyText} />
+				)}
 			</div>
+
 			{data.headliners?.no?.length > 0 && (
 				<Headliners
 					content={data.headliners}
 					featuredEvents={data.featuredEvents}
 				/>
 			)}
+
 			{data.callToAction && <Advertisement content={data.callToAction.no} />}
+
 			<div css={body}>
 				{data.featuredArticles && (
 					<FeaturedArticles content={data.featuredArticles} />
 				)}
 			</div>
+
 			{data.partners && <PartnerPreview content={data.partners} />}
+
 			<Seo
 				openGraph={{
 					title: "Hjem",

--- a/web/src/pages/not-found.tsx
+++ b/web/src/pages/not-found.tsx
@@ -17,7 +17,6 @@ const body = css`
 `;
 
 const hero = css`
-	color: white;
 	text-align: center;
 `;
 

--- a/web/src/pages/not-found.tsx
+++ b/web/src/pages/not-found.tsx
@@ -31,7 +31,6 @@ const NotFound: React.FC<RouteComponentProps> = () => {
 				<meta name="robots" content="noindex" />
 			</Helmet>
 			<Hero
-				angleDirection="<"
 				height="500px"
 				color={[theme.color.main.purple]}
 				imageUrl=""

--- a/web/src/pages/not-found.tsx
+++ b/web/src/pages/not-found.tsx
@@ -34,7 +34,7 @@ const NotFound: React.FC<RouteComponentProps> = () => {
 				height="500px"
 				color={[theme.color.main.purple]}
 				imageUrl=""
-				textPosition="center"
+				centerContent
 				css={hero}
 			>
 				<h1>404 - Siden finnes ikke</h1>

--- a/web/src/pages/page.tsx
+++ b/web/src/pages/page.tsx
@@ -56,7 +56,6 @@ const Page: React.FC<Props> = props => {
 	return (
 		<>
 			<Hero
-				angleDirection="<"
 				height="500px"
 				color={[theme.color.main.purple]}
 				imageUrl={

--- a/web/src/pages/page.tsx
+++ b/web/src/pages/page.tsx
@@ -13,11 +13,9 @@ import NotFound from "./not-found";
 import Error from "./error";
 
 const hero = css`
-	color: #ffffff;
 	text-align: center;
 
 	h2 {
-		font-size: 4rem;
 		margin: 0 0 2rem 0;
 	}
 

--- a/web/src/pages/page.tsx
+++ b/web/src/pages/page.tsx
@@ -64,7 +64,7 @@ const Page: React.FC<Props> = props => {
 						.url() || ""
 				}
 				css={hero}
-				textPosition="center"
+				centerContent
 				displayScrollButton
 			>
 				<h2>{page.header.no.title}</h2>

--- a/web/src/pages/partner-overview.tsx
+++ b/web/src/pages/partner-overview.tsx
@@ -18,11 +18,9 @@ import Error from "./error";
 type Props = { slug?: string } & RouteComponentProps;
 
 const hero = css`
-	color: #ffffff;
 	text-align: center;
 
 	h2 {
-		font-size: 4rem;
 		margin: 0 0 2rem 0;
 	}
 

--- a/web/src/pages/partner-overview.tsx
+++ b/web/src/pages/partner-overview.tsx
@@ -77,7 +77,6 @@ const PartnerOverview: React.FC<Props> = () => {
 	return (
 		<>
 			<Hero
-				angleDirection="<"
 				height="400px"
 				color={[theme.color.main.purple]}
 				imageUrl={

--- a/web/src/pages/partner-overview.tsx
+++ b/web/src/pages/partner-overview.tsx
@@ -85,7 +85,7 @@ const PartnerOverview: React.FC<Props> = () => {
 						.url() || ""
 				}
 				css={hero}
-				textPosition="center"
+				centerContent
 				displayScrollButton
 			>
 				<h2>{page.title.no}</h2>


### PR DESCRIPTION
### Adds option to display text section between hero and first CTA block on front page

Basically adds CSS to the already existing (currently empty) body block that'll make sure to display the text correctly. It will only display the text once the content is added through Sanity (the "body" block in "front-page" in Sanity).

Fixes issue #178 🔧 

#### ⚠️ WARNING:
_This PR also includes a lot of small changes to the hero component related code to clean it up and make it easier to edit in the future!_