### PR TITLE
Fix hero content overflow

### DIFF
--- a/web/src/components/hero.tsx
+++ b/web/src/components/hero.tsx
@@ -9,6 +9,7 @@ const hero = css`
 	padding-top: 13rem;
 	padding-bottom: 7rem;
 	color: #ffffff;
+	overflow-wrap: break-word;
 
 	h2 {
 		font-size: 4rem;

--- a/web/src/components/hero.tsx
+++ b/web/src/components/hero.tsx
@@ -3,10 +3,11 @@ import { css } from "@emotion/core";
 import BackgroundImage from "./background-image";
 import theme from "../utils/theme";
 
-const hero = (height: string) => css`
+const hero = css`
+	position: relative;
 	min-height: 400px;
-	height: ${height};
 	padding-top: 13rem;
+	padding-bottom: 7rem;
 	color: #ffffff;
 
 	h2 {
@@ -15,23 +16,22 @@ const hero = (height: string) => css`
 
 	@media screen and (max-width: 800px) {
 		padding-top: 8rem;
+		padding-bottom: 2rem;
 	}
 `;
 
-const image = (height: string) => css`
+const image = css`
 	position: absolute;
 	top: 0;
-	left: 0;
 	width: 100%;
-	height: ${height};
-	min-height: 350px;
+	height: 100%;
 	z-index: -1;
 `;
 
-const scrollButton = (height: string) => css`
+const scrollButton = css`
 	display: block;
 	position: absolute;
-	top: calc(${height} - 1.5rem);
+	top: calc(100% - 1.5rem);
 	left: 50%;
 	transform: translateX(-50%);
 	height: 3rem;
@@ -70,7 +70,6 @@ const centeredContent = css`
 `;
 
 type Props = {
-	height: string;
 	imageUrl: string;
 	color: Array<string>;
 	overflow?: boolean;
@@ -80,7 +79,7 @@ type Props = {
 };
 
 const Hero: React.FC<Props> = props => {
-	const { height, imageUrl, color, className, children } = props;
+	const { imageUrl, color, className, children } = props;
 
 	const scrollButtonRef = React.useRef<HTMLButtonElement>(null);
 
@@ -93,12 +92,8 @@ const Hero: React.FC<Props> = props => {
 	}
 
 	return (
-		<div css={hero(height)}>
-			<BackgroundImage
-				imageUrl={imageUrl}
-				overlayColor={color}
-				css={image(height)}
-			/>
+		<div css={hero}>
+			<BackgroundImage imageUrl={imageUrl} overlayColor={color} css={image} />
 			<div
 				className={className}
 				css={[defaultContent, props.centerContent && centeredContent]}
@@ -110,7 +105,7 @@ const Hero: React.FC<Props> = props => {
 				<button
 					title="Bla ned til hovedinnholdet"
 					ref={scrollButtonRef}
-					css={scrollButton(height)}
+					css={scrollButton}
 					onClick={scrollToContent}
 				>
 					<span role="img" aria-label="Nedoverpil">

--- a/web/src/components/hero.tsx
+++ b/web/src/components/hero.tsx
@@ -99,10 +99,11 @@ const Hero: React.FC<Props> = props => {
 				overlayColor={color}
 				css={image(height)}
 			/>
-			<div className={className}>
-				<div css={[defaultContent, props.centerContent && centeredContent]}>
-					{children}
-				</div>
+			<div
+				className={className}
+				css={[defaultContent, props.centerContent && centeredContent]}
+			>
+				{children}
 			</div>
 
 			{props.displayScrollButton && (

--- a/web/src/components/hero.tsx
+++ b/web/src/components/hero.tsx
@@ -32,7 +32,7 @@ const image = css`
 const scrollButton = css`
 	display: block;
 	position: absolute;
-	top: calc(100% - 1.5rem);
+	bottom: -1.5rem;
 	left: 50%;
 	transform: translateX(-50%);
 	height: 3rem;

--- a/web/src/pages/article-overview.tsx
+++ b/web/src/pages/article-overview.tsx
@@ -33,6 +33,7 @@ const body = css`
 	margin-top: -8rem;
 	width: 90vw;
 	max-width: 900px;
+	overflow-wrap: break-word;
 
 	p {
 		margin-bottom: 0;

--- a/web/src/pages/article-overview.tsx
+++ b/web/src/pages/article-overview.tsx
@@ -16,6 +16,7 @@ type Props = { slug?: string } & RouteComponentProps;
 
 const hero = css`
 	text-align: center;
+	padding-bottom: 4rem;
 
 	h2 {
 		margin: 0 0 2rem 0;
@@ -45,6 +46,10 @@ const body = css`
 	h3 {
 		margin: 0;
 		font-size: 1.75rem;
+	}
+
+	@media screen and (max-width: 800px) {
+		margin-top: -3rem;
 	}
 `;
 
@@ -104,7 +109,6 @@ const ArticleOverview: React.FC<Props> = () => {
 	return (
 		<>
 			<Hero
-				height="600px"
 				color={[theme.color.main.purple]}
 				imageUrl={
 					urlFor(archive.image)

--- a/web/src/pages/article.tsx
+++ b/web/src/pages/article.tsx
@@ -62,7 +62,6 @@ const Article: React.FC<Props> = props => {
 	return (
 		<>
 			<Hero
-				height="500px"
 				color={[theme.color.main.purple]}
 				imageUrl={
 					urlFor(article.image)

--- a/web/src/pages/article.tsx
+++ b/web/src/pages/article.tsx
@@ -33,6 +33,7 @@ const body = css`
 	margin-left: auto;
 	margin-right: auto;
 	margin-top: 4rem;
+	overflow-wrap: break-word;
 
 	p,
 	blockquote,

--- a/web/src/pages/error.tsx
+++ b/web/src/pages/error.tsx
@@ -39,7 +39,6 @@ const ErrorPage: React.FC<Props & RouteComponentProps> = ({ error }) => {
 				<meta name="robots" content="noindex" />
 			</Helmet>
 			<Hero
-				height="500px"
 				color={[theme.color.main.purple]}
 				imageUrl=""
 				centerContent

--- a/web/src/pages/event-overview.tsx
+++ b/web/src/pages/event-overview.tsx
@@ -261,7 +261,6 @@ const EventOverview: React.FC<Props> = () => {
 	return (
 		<>
 			<Hero
-				height="60vh"
 				color={[theme.color.main.purple, theme.color.main.pink]}
 				imageUrl={
 					urlFor(archive.image)

--- a/web/src/pages/front-page.tsx
+++ b/web/src/pages/front-page.tsx
@@ -95,7 +95,6 @@ const FrontPage: React.FC<Props> = () => {
 	return (
 		<>
 			<Hero
-				height="720px"
 				color={[theme.color.main.purple, theme.color.main.pink]}
 				imageUrl={
 					urlFor(data.header.no.image)

--- a/web/src/pages/not-found.tsx
+++ b/web/src/pages/not-found.tsx
@@ -31,7 +31,6 @@ const NotFound: React.FC<RouteComponentProps> = () => {
 				<meta name="robots" content="noindex" />
 			</Helmet>
 			<Hero
-				height="500px"
 				color={[theme.color.main.purple]}
 				imageUrl=""
 				centerContent

--- a/web/src/pages/page.tsx
+++ b/web/src/pages/page.tsx
@@ -56,7 +56,6 @@ const Page: React.FC<Props> = props => {
 	return (
 		<>
 			<Hero
-				height="500px"
 				color={[theme.color.main.purple]}
 				imageUrl={
 					urlFor(page.header.no.image)

--- a/web/src/pages/partner-overview.tsx
+++ b/web/src/pages/partner-overview.tsx
@@ -77,7 +77,6 @@ const PartnerOverview: React.FC<Props> = () => {
 	return (
 		<>
 			<Hero
-				height="400px"
 				color={[theme.color.main.purple]}
 				imageUrl={
 					urlFor(page.image)


### PR DESCRIPTION
This removes fixed height from the hero component and makes it adjust automatically based on content.

I also added overflow wrapping that breaks up very long words in article titles so they don't break out of their containers. A good example is the word "kommunikasjonsrådgiver" in [this article](https://www.oslopride.no/a/kommunikasjonsradgiver) (view on a small screen 📱)

Fixes issue #191 🔨