### PR TITLE
Revert "fix: set hero min height to 100vh"

### DIFF
--- a/web/src/components/hero.tsx
+++ b/web/src/components/hero.tsx
@@ -5,7 +5,7 @@ import theme from "../utils/theme";
 
 const hero = css`
 	position: relative;
-	min-height: 100vh;
+	min-height: 400px;
 	padding-top: 13rem;
 	padding-bottom: 7rem;
 	color: #ffffff;


### PR DESCRIPTION
Reverts oslopride/oslopride.no#196

Oopsie, approved this too eagerly. It was setting 100vh on all heros. Another attempt at a quick fix did not work so I'm just reverting this for now.