### PR TITLE
add publishedAt to articles

### DIFF
--- a/sanity/schemas/article.js
+++ b/sanity/schemas/article.js
@@ -26,6 +26,13 @@ export default {
 			validation: Rule => Rule.required()
 		},
 		{
+			title: "Publish date",
+			name: "publishedAt",
+			type: "date",
+			description: "Set the publishing date of article",
+			validation: Rule => Rule.required()
+		},
+		{
 			title: "Image",
 			name: "image",
 			type: "image",

--- a/web/src/blocks/featured-articles.tsx
+++ b/web/src/blocks/featured-articles.tsx
@@ -6,9 +6,13 @@ import { SanityArticle } from "../sanity/models";
 import { urlFor } from "../sanity";
 import theme from "../utils/theme";
 import { LinkButton } from "../components/link";
+import { format } from "date-fns";
+import { nb } from "date-fns/locale";
 
-const formatDate = (date: Date): string =>
-	date.toLocaleDateString("nb-NO", { month: "long", year: "numeric" });
+const formatDate = (date: string): string =>
+	format(new Date(date), "do MMMM yyyy", {
+		locale: nb
+	});
 
 const ArticleList = styled.ul`
 	display: flex;
@@ -115,7 +119,7 @@ const ArticlePreview = ({ article }: ArticlePreviewProps) => (
 					}
 				/>
 			)}
-			<time>{formatDate(new Date(article._createdAt))}</time>
+			<time>{formatDate(article.publishedAt || article._createdAt)}</time>
 			<h4>{article.title.no}</h4>
 		</a>
 	</ArticleStyled>

--- a/web/src/pages/article.tsx
+++ b/web/src/pages/article.tsx
@@ -123,7 +123,7 @@ const Article: React.FC<Props> = props => {
 
 	// get all articles in order to get next and prev from currently viewed article
 	const { data: articleList } = useSWR<Array<SanityArticle>>(
-		`*[_type == "article"]{ _id, title, slug }  | order(_createdAt desc)`
+		`*[_type == "article"]{ _id, title, slug }  | order(publishedAt desc, _createdAt desc)`
 	);
 
 	const indexOfCurrentArticle =
@@ -144,9 +144,14 @@ const Article: React.FC<Props> = props => {
 	if (article === undefined) return <Loading />;
 	if (article === null) return <NotFound />;
 
-	const formattedDate = format(new Date(article._createdAt), "do MMMM yyyy", {
-		locale: nb
-	});
+	// Try using publishedAt date if it exists first, otherwise fall back to _createdAt date
+	const formattedDate = format(
+		new Date(article.publishedAt || article._createdAt),
+		"do MMMM yyyy",
+		{
+			locale: nb
+		}
+	);
 
 	return (
 		<>
@@ -161,7 +166,7 @@ const Article: React.FC<Props> = props => {
 				displayScrollButton
 				centerContent
 			>
-				<time css={date} dateTime={article._createdAt}>
+				<time css={date} dateTime={article.publishedAt || article._createdAt}>
 					{formattedDate}
 				</time>
 				<h2>{article.title.no}</h2>
@@ -200,7 +205,7 @@ const Article: React.FC<Props> = props => {
 					description: article.summary?.no || "Oslo Pride",
 					url: `https://www.oslopride.no/a/${slug}`,
 					locale: "nb_NO",
-					publishedAt: article._createdAt || "",
+					publishedAt: article.publishedAt || article._createdAt || "",
 					modifiedAt: article._updatedAt || "",
 					image: {
 						url:

--- a/web/src/sanity/models.ts
+++ b/web/src/sanity/models.ts
@@ -213,6 +213,7 @@ export type SanityArticle = SanityDocument<
 	{
 		slug: { current: string };
 		title: Locale<string>;
+		publishedAt: string;
 		image: SanityImage;
 		summary: Locale<string>;
 		body: Locale<SanityObjectArray<SanityBlock>>;


### PR DESCRIPTION
Solves a problem where we either had to pick between using `_createdAt` or `_updatedAt` for article publishing dates. The created date would be the creation date of the initial draft (i.e. working on an article over a longer period of time would not reflect the real publishing date).

- Add a required `publishedAt` field to articles
- Fallback to `_createdAt` if publishedAt does not exist (for old articles)
- Sort by `publishedAt`, then `_createdAt`
- Use a common format with `date-fns` to get localized dates (could still use some improvements...)

Fixes #207 