### PR TITLE
Fix button focus behavior

### DIFF
--- a/web/src/components/link.tsx
+++ b/web/src/components/link.tsx
@@ -140,7 +140,8 @@ export const LinkButton = styled(Link)<LinkButtonProps>`
 	font-weight: bold;
 	transition: color 0.3s, background 0.3s;
 
-	:hover {
+	:hover,
+	:focus {
 		color: #ffffff;
 		background-color: ${theme.color.main.purple};
 	}


### PR DESCRIPTION
This simple fix solves issue #205 by making the link buttons change colors in the same way when focused 🔍  as on mouse hover 🐭 