### PR TITLE
Add "allied" as new partner type

### DIFF
--- a/sanity/schemas/partner.js
+++ b/sanity/schemas/partner.js
@@ -16,7 +16,7 @@ export default {
 			name: "type",
 			title: "Partner type",
 			type: "string",
-			options: { list: ["owner", "main", "regular", "supporter"] }
+			options: { list: ["owner", "main", "regular", "supporter", "allied"] }
 		},
 		{
 			name: "description",

--- a/web/src/blocks/partner-list.tsx
+++ b/web/src/blocks/partner-list.tsx
@@ -160,6 +160,24 @@ const PartnerList: FC<Props> = ({ content }) => {
 						))}
 				</div>
 			</div>
+			<div>
+				<h2 css={groupHeader}>Allierte</h2>
+				<div css={SupporterFlexBox}>
+					{content
+						.filter(p => p.type === "allied")
+						.map(partner => (
+							<img
+								key={partner._id}
+								src={
+									urlFor(partner.image)
+										.width(200)
+										.url() || undefined
+								}
+								alt={`${partner.name} logo`}
+							/>
+						))}
+				</div>
+			</div>
 		</>
 	);
 };

--- a/web/src/blocks/partner-list.tsx
+++ b/web/src/blocks/partner-list.tsx
@@ -9,7 +9,7 @@ type Props = {
 	content: SanityPartnerList;
 };
 
-const SupporterFlexBox = css`
+const PartnerFlexBox = css`
 	display: flex;
 	flex-wrap: wrap;
 	justify-content: space-around;
@@ -69,7 +69,7 @@ const PartnerList: FC<Props> = ({ content }) => {
 		<>
 			<div>
 				<h2 css={groupHeader}>Eier og arrangør</h2>
-				<div css={SupporterFlexBox}>
+				<div css={PartnerFlexBox}>
 					{content
 						.filter(p => p.type === "owner")
 						.map(partner => (
@@ -94,7 +94,7 @@ const PartnerList: FC<Props> = ({ content }) => {
 			</div>
 			<div>
 				<h2 css={groupHeader}>Hovedpartnere</h2>
-				<div css={SupporterFlexBox}>
+				<div css={PartnerFlexBox}>
 					{content
 						.filter(p => p.type === "main")
 						.map(partner => (
@@ -119,7 +119,7 @@ const PartnerList: FC<Props> = ({ content }) => {
 			</div>
 			<div>
 				<h2 css={groupHeader}>Partnere</h2>
-				<div css={SupporterFlexBox}>
+				<div css={PartnerFlexBox}>
 					{content
 						.filter(p => p.type === "regular")
 						.map(partner => (
@@ -144,7 +144,7 @@ const PartnerList: FC<Props> = ({ content }) => {
 			</div>
 			<div>
 				<h2 css={groupHeader}>Støttespillere</h2>
-				<div css={SupporterFlexBox}>
+				<div css={PartnerFlexBox}>
 					{content
 						.filter(p => p.type === "supporter")
 						.map(partner => (
@@ -162,7 +162,7 @@ const PartnerList: FC<Props> = ({ content }) => {
 			</div>
 			<div>
 				<h2 css={groupHeader}>Allierte</h2>
-				<div css={SupporterFlexBox}>
+				<div css={PartnerFlexBox}>
 					{content
 						.filter(p => p.type === "allied")
 						.map(partner => (

--- a/web/src/blocks/partner-list.tsx
+++ b/web/src/blocks/partner-list.tsx
@@ -164,24 +164,27 @@ const PartnerList: FC<Props> = ({ content }) => {
 						))}
 				</div>
 			</div>
-			<AlliedWrap>
-				<h2 css={groupHeader}>Allierte</h2>
-				<div css={PartnerFlexBox}>
-					{content
-						.filter(p => p.type === "allied")
-						.map(partner => (
-							<img
-								key={partner._id}
-								src={
-									urlFor(partner.image)
-										.width(200)
-										.url() || undefined
-								}
-								alt={`${partner.name} logo`}
-							/>
-						))}
-				</div>
-			</AlliedWrap>
+
+			{content.filter(p => p.type === "allied").length > 0 && (
+				<AlliedWrap>
+					<h2 css={groupHeader}>Allierte</h2>
+					<div css={PartnerFlexBox}>
+						{content
+							.filter(p => p.type === "allied")
+							.map(partner => (
+								<img
+									key={partner._id}
+									src={
+										urlFor(partner.image)
+											.width(200)
+											.url() || undefined
+									}
+									alt={`${partner.name} logo`}
+								/>
+							))}
+					</div>
+				</AlliedWrap>
+			)}
 		</>
 	);
 };

--- a/web/src/blocks/partner-list.tsx
+++ b/web/src/blocks/partner-list.tsx
@@ -64,6 +64,10 @@ const groupHeader = css`
 	}
 `;
 
+const AlliedWrap = styled.div`
+	margin-top: 5rem;
+`;
+
 const PartnerList: FC<Props> = ({ content }) => {
 	return (
 		<>
@@ -160,7 +164,7 @@ const PartnerList: FC<Props> = ({ content }) => {
 						))}
 				</div>
 			</div>
-			<div>
+			<AlliedWrap>
 				<h2 css={groupHeader}>Allierte</h2>
 				<div css={PartnerFlexBox}>
 					{content
@@ -177,7 +181,7 @@ const PartnerList: FC<Props> = ({ content }) => {
 							/>
 						))}
 				</div>
-			</div>
+			</AlliedWrap>
 		</>
 	);
 };

--- a/web/src/blocks/partner-preview.tsx
+++ b/web/src/blocks/partner-preview.tsx
@@ -136,6 +136,10 @@ const PartnerPreview: React.FC<PartnerPreviewProps> = ({ content }) => {
 					name="Støttespillere"
 					partners={content.filter(p => p.type === "supporter")}
 				/>
+				<PartnerGroup
+					name="Allierte"
+					partners={content.filter(p => p.type === "allied")}
+				/>
 			</ul>
 		</section>
 	);

--- a/web/src/blocks/partner-preview.tsx
+++ b/web/src/blocks/partner-preview.tsx
@@ -136,10 +136,13 @@ const PartnerPreview: React.FC<PartnerPreviewProps> = ({ content }) => {
 					name="Støttespillere"
 					partners={content.filter(p => p.type === "supporter")}
 				/>
-				<PartnerGroup
-					name="Allierte"
-					partners={content.filter(p => p.type === "allied")}
-				/>
+
+				{content.filter(p => p.type === "allied").length > 0 && (
+					<PartnerGroup
+						name="Allierte"
+						partners={content.filter(p => p.type === "allied")}
+					/>
+				)}
 			</ul>
 		</section>
 	);


### PR DESCRIPTION
This adds an option for a new partner type called "allied".

The "allied" type has been added to the list of partner types in Sanity.
It also has it's own section on the partners page and in the partner preview on the front page. The section is currently hidden as there are no allied partners to display but will appear as soon as they are added inside Sanity.

Fixes issue #217 🔨