### PR TITLE
Add new arenas and venues

### DIFF
--- a/sanity/schemas/simple-event.js
+++ b/sanity/schemas/simple-event.js
@@ -143,9 +143,10 @@ export default {
 					{ title: "Pride House", value: "house" },
 					{ title: "Pride Parade", value: "parade" },
 					{ title: "Mini Pride", value: "minipride" },
-					{ title: "Pride square", value: "square" },
+					{ title: "Salt", value: "salt" },
 					{ title: "External", value: "external" },
-					{ title: "Other", value: "other" }
+					{ title: "Other", value: "other" },
+					{ title: "Pride square", value: "square" }
 				]
 			},
 			fieldset: "location",
@@ -157,8 +158,12 @@ export default {
 			options: {
 				list: [
 					{ title: "Hovedscenen", value: "stage1" },
-					{ title: "BamseScenen", value: "stage2" },
-					{ title: "Kulturhuset", value: "kultur" },
+					{ title: "Bamsescenen", value: "stage2" },
+					{ title: "Kulturscenen", value: "kultur" },
+					{ title: "Eyr", value: "eyr" },
+					{ title: "Hippokrates", value: "hippo" },
+					{ title: "Bjerget", value: "bjerget" },
+					{ title: "Schjelderup", value: "schjelderup" },
 					{ title: "Mini Pride", value: "minipride" },
 					{ title: "Pride Box", value: "box" },
 					{ title: "Loud ‘n’ Proud", value: "loudproud" },

--- a/web/src/pages/event-overview.tsx
+++ b/web/src/pages/event-overview.tsx
@@ -215,9 +215,9 @@ const arenaFilters: Filter[] = [
 		predicate: event => event.arena === "parade"
 	},
 	{
-		value: "square",
-		label: "Pride Square",
-		predicate: event => event.arena === "square"
+		value: "salt",
+		label: "Salt",
+		predicate: event => event.arena === "salt"
 	},
 	{
 		value: "minipride",

--- a/web/src/pages/event.tsx
+++ b/web/src/pages/event.tsx
@@ -115,6 +115,8 @@ const getArenaName = (arena: SanitySimpleEvent["arena"]) => {
 			return "Pride House";
 		case "parade":
 			return "Pride Parade";
+		case "salt":
+			return "Salt";
 		case "square":
 			return "Pride Square";
 		case "external":
@@ -129,9 +131,17 @@ const getVenueName = (venue: SanitySimpleEvent["venue"]) => {
 		case "stage1":
 			return "Hovedscenen";
 		case "stage2":
-			return "BamseScenen";
+			return "Bamsescenen";
 		case "kultur":
-			return "Kulturhuset";
+			return "Kulturscenen";
+		case "eyr":
+			return "Eyr";
+		case "hippo":
+			return "Hippokrates";
+		case "bjerget":
+			return "Bjerget";
+		case "schjelderup":
+			return "Schjelderup";
 		case "loudproud":
 			return "Loud ‘n’ Proud";
 		case "box":

--- a/web/src/sanity/models.ts
+++ b/web/src/sanity/models.ts
@@ -188,6 +188,7 @@ export type SanitySimpleEvent = SanityDocument<
 			| "house"
 			| "parade"
 			| "external"
+			| "salt"
 			| "square"
 			| "other"
 			| "minipride";
@@ -197,6 +198,10 @@ export type SanitySimpleEvent = SanityDocument<
 			| "loudproud"
 			| "box"
 			| "kultur"
+			| "eyr"
+			| "hippo"
+			| "bjerget"
+			| "schjelderup"
 			| "minipride"
 			| "online"
 			| "youngs";


### PR DESCRIPTION
Adding new venue Salt, as well as arenas Eyr, Hippokrates, Bjerget and Schjelderup. Removing Pride Square from visible filter, but keeping all deprecated venues and arenas in Sanity so as to not invalidate existing data. 