### PR TITLE
Add new arenas and venues for 2024

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll": true
+    "source.fixAll": "explicit"
   },
   "[typescript]": {
     "editor.formatOnSave": true

--- a/sanity/schemas/simple-event.js
+++ b/sanity/schemas/simple-event.js
@@ -152,7 +152,8 @@ export default {
 					{ title: "Salt", value: "salt" },
 					{ title: "External", value: "external" },
 					{ title: "Other", value: "other" },
-					{ title: "Pride square", value: "square" }
+					{ title: "Pride square", value: "square" },
+					{ title: "Skeive Scener", value: "scener" }
 				]
 			},
 			fieldset: "location",
@@ -169,12 +170,14 @@ export default {
 					{ title: "Eyr", value: "eyr" },
 					{ title: "Hippokrates", value: "hippo" },
 					{ title: "Bjerget", value: "bjerget" },
+					{ title: "Isachsen", value: "isachsen" },
 					{ title: "Schjelderup", value: "schjelderup" },
 					{ title: "Mini Pride", value: "minipride" },
 					{ title: "Pride Box", value: "box" },
 					{ title: "Loud ‘n’ Proud", value: "loudproud" },
 					{ title: "Online", value: "online" },
-					{ title: "Youngs", value: "youngs" }
+					{ title: "Youngs", value: "youngs" },
+					{ title: "Skeive Scener", value: "scener" }
 				]
 			},
 			fieldset: "location"

--- a/web/src/pages/event.tsx
+++ b/web/src/pages/event.tsx
@@ -123,6 +123,8 @@ const getArenaName = (arena: SanitySimpleEvent["arena"]) => {
 			return "Eksternt arrangement";
 		case "minipride":
 			return "Mini Pride";
+		case "scener":
+			return "Skeive Scener";
 		default:
 			return "Annet";
 	}
@@ -142,6 +144,8 @@ const getVenueName = (venue: SanitySimpleEvent["venue"]) => {
 			return "Hippokrates";
 		case "bjerget":
 			return "Bjerget";
+		case "isachsen":
+			return "Isachsen";
 		case "schjelderup":
 			return "Schjelderup";
 		case "loudproud":
@@ -154,6 +158,8 @@ const getVenueName = (venue: SanitySimpleEvent["venue"]) => {
 			return "Youngs";
 		case "minipride":
 			return "Mini Pride";
+		case "scener":
+			return "Skeive Scener";
 		default:
 			return "Annet";
 	}

--- a/web/src/sanity/models.ts
+++ b/web/src/sanity/models.ts
@@ -194,7 +194,8 @@ export type SanitySimpleEvent = SanityDocument<
 			| "salt"
 			| "square"
 			| "other"
-			| "minipride";
+			| "minipride"
+			| "scener";
 		venue?:
 			| "stage1"
 			| "stage2"
@@ -204,10 +205,12 @@ export type SanitySimpleEvent = SanityDocument<
 			| "eyr"
 			| "hippo"
 			| "bjerget"
+			| "isachsen"
 			| "schjelderup"
 			| "minipride"
 			| "online"
-			| "youngs";
+			| "youngs"
+			| "scener";
 		address?: string;
 		signLanguageInterpreted: boolean;
 		simultaneousTexting: boolean;


### PR DESCRIPTION
Adding Isachsen to venues, and Skeive Scener to both arenas and venues per request. Note that this does not add filtering options for Skeive Scener as an arena, as this isn't necessary if it ends up being used as a venue.